### PR TITLE
replace deprecated View.cornerRadius with clipShape(RoundedRectangle)

### DIFF
--- a/Input Source Pro/UI/Components/AccessibilityPermissionRequestView.swift
+++ b/Input Source Pro/UI/Components/AccessibilityPermissionRequestView.swift
@@ -19,7 +19,7 @@ struct AccessibilityPermissionRequestView: View {
                 }
                 .font(.system(size: 10).weight(.bold))
                 .frame(width: 18, height: 18)
-                .cornerRadius(99)
+                .clipShape(RoundedRectangle(cornerRadius: 99))
                 .disabled(isDisableTips)
 
                 Spacer()

--- a/Input Source Pro/UI/Components/BrowserPermissionRequestView.swift
+++ b/Input Source Pro/UI/Components/BrowserPermissionRequestView.swift
@@ -58,7 +58,7 @@ struct BrowserPermissionRequestView: View {
                 }
                 .font(.system(size: 10).weight(.bold))
                 .frame(width: 18, height: 18)
-                .cornerRadius(99)
+                .clipShape(RoundedRectangle(cornerRadius: 99))
                 .disabled(isDisableTips)
 
                 Spacer()

--- a/Input Source Pro/UI/Components/BrowserRuleEditView.swift
+++ b/Input Source Pro/UI/Components/BrowserRuleEditView.swift
@@ -74,7 +74,7 @@ struct BrowserRuleEditView: View {
                             }
                             .font(.system(size: 10).weight(.bold))
                             .frame(width: 18, height: 18)
-                            .cornerRadius(99)
+                            .clipShape(RoundedRectangle(cornerRadius: 99))
                             .popover(
                                 isPresented: self.$isPopover,
                                 arrowEdge: .bottom
@@ -110,7 +110,7 @@ struct BrowserRuleEditView: View {
                 }
                 .padding()
                 .background(Color.gray.opacity(0.1))
-                .cornerRadius(8)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
                 .padding(.bottom)
             }
 
@@ -147,7 +147,7 @@ struct BrowserRuleEditView: View {
                 }
                 .padding()
                 .background(Color.gray.opacity(0.1))
-                .cornerRadius(8)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
                 .padding(.bottom)
             }
 
@@ -170,7 +170,7 @@ struct BrowserRuleEditView: View {
                 }
                 .padding()
                 .background(Color.gray.opacity(0.1))
-                .cornerRadius(8)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
                 .padding(.bottom)
             }
 

--- a/Input Source Pro/UI/Components/BrowserRuleRow.swift
+++ b/Input Source Pro/UI/Components/BrowserRuleRow.swift
@@ -42,7 +42,7 @@ struct BrowserRuleRow: View {
                 .padding(.vertical, 2)
                 .foregroundColor(.white)
                 .background(Color.accentColor)
-                .cornerRadius(2)
+                .clipShape(RoundedRectangle(cornerRadius: 2))
 
             Button("Edit") {
                 showModal = true

--- a/Input Source Pro/UI/Components/EnhancedModeRequiredBadge.swift
+++ b/Input Source Pro/UI/Components/EnhancedModeRequiredBadge.swift
@@ -21,7 +21,7 @@ struct EnhanceMoreRequiredButtonStyle: ButtonStyle {
             .padding(.vertical, 3)
             .background(Color.yellow)
             .foregroundColor(Color.black)
-            .cornerRadius(4)
+            .clipShape(RoundedRectangle(cornerRadius: 4))
             .contentShape(Rectangle())
     }
 }

--- a/Input Source Pro/UI/Components/ISPTextEditor.swift
+++ b/Input Source Pro/UI/Components/ISPTextEditor.swift
@@ -23,7 +23,7 @@ struct ISPTextEditor: View {
                 .foregroundColor(Color(.labelColor))
                 .multilineTextAlignment(.leading)
                 .background(Color(NSColor.textBackgroundColor))
-                .cornerRadius(6.0)
+                .clipShape(RoundedRectangle(cornerRadius: 6))
                 .overlay(
                     RoundedRectangle(cornerRadius: 6)
                         .stroke(Color.primary.opacity(0.3), lineWidth: 1)

--- a/Input Source Pro/UI/Components/IndicatorPositionEditor.swift
+++ b/Input Source Pro/UI/Components/IndicatorPositionEditor.swift
@@ -184,17 +184,14 @@ private extension IndicatorPosition.Alignment {
     func indicator() -> some View {
         switch self {
         case .center:
-            Rectangle()
+            RoundedRectangle(cornerRadius: 3)
                 .frame(width: 30, height: 30)
-                .cornerRadius(3)
         case .topCenter, .bottomCenter:
-            Rectangle()
+            RoundedRectangle(cornerRadius: 2)
                 .frame(width: 44, height: 8)
-                .cornerRadius(2)
         case .centerLeft, .centerRight:
-            Rectangle()
+            RoundedRectangle(cornerRadius: 2)
                 .frame(width: 8, height: 30)
-                .cornerRadius(2)
         default:
             Image(nsImage: .triangle)
                 .resizable()

--- a/Input Source Pro/UI/Components/ItemSection.swift
+++ b/Input Source Pro/UI/Components/ItemSection.swift
@@ -25,7 +25,7 @@ struct ItemSectionStyle: ViewModifier {
     func body(content: Content) -> some View {
         content
             .background(NSColor.background1.color)
-            .cornerRadius(6)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
             .overlay(
                 RoundedRectangle(cornerRadius: 6)
                     .stroke(NSColor.border2.color, lineWidth: 1)

--- a/Input Source Pro/UI/Components/MockWindowView.swift
+++ b/Input Source Pro/UI/Components/MockWindowView.swift
@@ -29,7 +29,7 @@ struct MockWindowView: View {
             }
             .padding(10)
         }
-        .cornerRadius(9)
+        .clipShape(RoundedRectangle(cornerRadius: 9))
         .shadow(color: Color.black.opacity(0.2), radius: 5, x: 3, y: 3)
     }
 }

--- a/Input Source Pro/UI/Components/QuestionMark.swift
+++ b/Input Source Pro/UI/Components/QuestionMark.swift
@@ -15,7 +15,7 @@ struct QuestionMark<Content: View>: View {
         }
         .font(.system(size: 10).weight(.bold))
         .frame(width: 18, height: 18)
-        .cornerRadius(99)
+        .clipShape(RoundedRectangle(cornerRadius: 99))
         .popover(isPresented: $isPresented, arrowEdge: .top) {
             content
         }

--- a/Input Source Pro/UI/Components/SettingsSection.swift
+++ b/Input Source Pro/UI/Components/SettingsSection.swift
@@ -35,7 +35,7 @@ struct SettingsSection<Content: View, Tips: View>: View {
             }
             .frame(maxWidth: .infinity)
             .background(NSColor.background2.color)
-            .cornerRadius(8)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
                     .stroke(NSColor.border2.color, lineWidth: 1)

--- a/Input Source Pro/UI/Screens/PositionSettingsView.swift
+++ b/Input Source Pro/UI/Screens/PositionSettingsView.swift
@@ -43,7 +43,7 @@ struct PositionSettingsView: View {
                 SettingsSection(title: "Position") {
                     VStack(spacing: 0) {
                         IndicatorPositionEditor()
-                            .cornerRadius(6)
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
                             .padding(.horizontal)
                             .padding(.top)
 
@@ -69,7 +69,7 @@ struct PositionSettingsView: View {
                                             .foregroundColor(.primary)
                                             .frame(width: 50, height: 25)
                                             .background(Color.primary.opacity(0.05))
-                                            .cornerRadius(6)
+                                            .clipShape(RoundedRectangle(cornerRadius: 6))
                                             .noAnimation()
                                     }
                                 }

--- a/Input Source Pro/UI/Screens/PreferencesView.swift
+++ b/Input Source Pro/UI/Screens/PreferencesView.swift
@@ -207,7 +207,7 @@ struct NavButtonStyle: ButtonStyle {
         .background(isActive ? Color.gray.opacity(0.2) : Color.clear)
         .background(configuration.isPressed ? Color.gray.opacity(0.1) : Color.clear)
         .foregroundColor(Color.primary)
-        .cornerRadius(6)
+        .clipShape(RoundedRectangle(cornerRadius: 6))
         .contentShape(Rectangle())
         .padding(.horizontal, 10)
     }

--- a/Input Source Pro/UI/Utilities/ButtonStyle.swift
+++ b/Input Source Pro/UI/Utilities/ButtonStyle.swift
@@ -35,7 +35,7 @@ struct SectionButtonStyle: ButtonStyle {
             .frame(maxWidth: .infinity)
             .background(configuration.isPressed ? Color.gray.opacity(0.05) : Color.clear)
             .foregroundColor(Color.accentColor)
-            .cornerRadius(6)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
             .contentShape(Rectangle())
     }
 }


### PR DESCRIPTION
Hello,

Replaces deprecated `cornerRadius(_:antialiased:)` with `clipShape(RoundedRectangle(cornerRadius:))`, maintaining identical UI appearance and layout.

Thank you for reviewing!

Apple Developer Documentation: [cornerRadius(_:antialiased:) → clipShape(RoundedRectangle)](https://developer.apple.com/documentation/swiftui/view/cornerradius(_:antialiased:))