### PR TITLE
feat: add support for Zen browser

### DIFF
--- a/Input Source Pro/Models/PreferencesVM+BrowserAddress.swift
+++ b/Input Source Pro/Models/PreferencesVM+BrowserAddress.swift
@@ -98,7 +98,7 @@ enum BrowserThatCanWatchBrowserAddressFocus: CaseIterable {
         return nil
     }
 
-    case Safari, SafariTechnologyPreview, Chrome, Chromium, Brave, BraveBeta, BraveNightly, Edge, Vivaldi, Arc, Opera, Firefox, FirefoxNightly, FirefoxDeveloperEdition
+    case Safari, SafariTechnologyPreview, Chrome, Chromium, Brave, BraveBeta, BraveNightly, Edge, Vivaldi, Arc, Opera, Firefox, FirefoxNightly, FirefoxDeveloperEdition, Zen
 
     var bundleIdentifier: String {
         return browser.rawValue
@@ -134,6 +134,8 @@ enum BrowserThatCanWatchBrowserAddressFocus: CaseIterable {
             return .FirefoxNightly
         case .FirefoxDeveloperEdition:
             return .FirefoxDeveloperEdition
+        case .Zen:
+            return .Zen
         }
     }
 
@@ -174,7 +176,7 @@ enum BrowserThatCanWatchBrowserAddressFocus: CaseIterable {
                 return false
             }
 
-        case .Firefox, .FirefoxNightly, .FirefoxDeveloperEdition:
+        case .Firefox, .FirefoxNightly, .FirefoxDeveloperEdition, .Zen:
             return focusedElement.firefoxDomIdentifier() == "urlbar-input"
         }
     }

--- a/Input Source Pro/Models/PreferencesVM+BrowserRule.swift
+++ b/Input Source Pro/Models/PreferencesVM+BrowserRule.swift
@@ -117,6 +117,8 @@ extension PreferencesVM {
             return preferences.isEnableURLSwitchForFirefoxDeveloperEdition
         case .FirefoxNightly:
             return preferences.isEnableURLSwitchForFirefoxNightly
+        case .Zen:
+            return preferences.isEnableURLSwitchForZen
         }
     }
 

--- a/Input Source Pro/Models/PreferencesVM.swift
+++ b/Input Source Pro/Models/PreferencesVM.swift
@@ -172,6 +172,8 @@ extension PreferencesVM {
             guard preferences.isEnableURLSwitchForFirefoxDeveloperEdition else { return nil }
         case .FirefoxNightly:
             guard preferences.isEnableURLSwitchForFirefoxNightly else { return nil }
+        case .Zen:
+            guard preferences.isEnableURLSwitchForZen else { return nil }
         }
 
         if let application = application,
@@ -238,6 +240,7 @@ struct Preferences {
         static let isEnableURLSwitchForFirefox = "isEnableURLSwitchForFirefox"
         static let isEnableURLSwitchForFirefoxDeveloperEdition = "isEnableURLSwitchForFirefoxDeveloperEdition"
         static let isEnableURLSwitchForFirefoxNightly = "isEnableURLSwitchForFirefoxNightly"
+        static let isEnableURLSwitchForZen = "isEnableURLSwitchForZen"
 
         static let isAutoAppearanceMode = "isAutoAppearanceMode"
         static let appearanceMode = "appearanceMode"
@@ -351,6 +354,9 @@ struct Preferences {
 
     @UserDefault(Preferences.Key.isEnableURLSwitchForFirefoxNightly)
     var isEnableURLSwitchForFirefoxNightly = false
+
+    @UserDefault(Preferences.Key.isEnableURLSwitchForZen)
+    var isEnableURLSwitchForZen = false
 
     // MARK: - Appearance
 

--- a/Input Source Pro/UI/Screens/BrowserRulesSettingsView.swift
+++ b/Input Source Pro/UI/Screens/BrowserRulesSettingsView.swift
@@ -175,6 +175,8 @@ struct BrowserRulesSettingsView: View {
                 $0.isEnableURLSwitchForFirefoxDeveloperEdition = isEnable
             case .FirefoxNightly:
                 $0.isEnableURLSwitchForFirefoxNightly = isEnable
+            case .Zen:
+                $0.isEnableURLSwitchForZen = isEnable
             }
         }
     }

--- a/Input Source Pro/Utilities/BrowserURL.swift
+++ b/Input Source Pro/Utilities/BrowserURL.swift
@@ -18,6 +18,7 @@ enum Browser: String, CaseIterable {
     case Firefox = "org.mozilla.firefox"
     case FirefoxDeveloperEdition = "org.mozilla.firefoxdeveloperedition"
     case FirefoxNightly = "org.mozilla.nightly"
+    case Zen = "app.zen-browser.zen"
 
     var displayName: String {
         switch self {
@@ -51,6 +52,8 @@ enum Browser: String, CaseIterable {
             return "Firefox Developer Edition"
         case .FirefoxNightly:
             return "Firefox Nightly"
+        case .Zen:
+            return "Zen"
         }
     }
 }


### PR DESCRIPTION
Glad to see InputSourcePro open-sourced!
In #6, I saw someone ask whether InputSourcePro could support the Zen browser, so I added support for it.
Zen browser works similarly to Firefox, both use `urlbar-input` as the identifier, and in my local testing, everything works well.
Looking forward to your review.