### PR TITLE
fix: fix open preferences on startup

### DIFF
--- a/Input Source Pro/System/AppDelegate.swift
+++ b/Input Source Pro/System/AppDelegate.swift
@@ -4,6 +4,8 @@ import SwiftUI
 import Alamofire
 
 class AppDelegate: NSObject, NSApplicationDelegate {
+    private var didJustLaunch = true
+
     var navigationVM: NavigationVM!
     var indicatorVM: IndicatorVM!
     var preferencesVM: PreferencesVM!
@@ -47,6 +49,12 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidBecomeActive(_: Notification) {
+        if didJustLaunch {
+            print("Skipping applicationDidBecomeActive on first launch")
+            didJustLaunch = false
+            return
+        }
+        print("applicationDidBecomeActive (not first launch)")
         statusItemController.openPreferences()
     }
 


### PR DESCRIPTION
This PR fixes an issue where the preferences window would open every time the app launches (including after macOS restart), due to applicationDidBecomeActive being triggered on first launch.

🛠️ Changes
	•	Added didJustLaunch flag in AppDelegate to track first activation after launch.
	•	Modified applicationDidBecomeActive to skip opening preferences window on first activation, while still allowing it to trigger on subsequent activations (e.g. switching back from another app).