### PR TITLE
Enhance Icon Consistency and Add Conditional Styling Based on Selection State

### DIFF
--- a/Input Source Pro/UI/Components/BrowserRuleEditView.swift
+++ b/Input Source Pro/UI/Components/BrowserRuleEditView.swift
@@ -160,7 +160,7 @@ struct BrowserRuleEditView: View {
                 VStack {
                     HStack {
                         HStack(spacing: 4) {
-                            Image(systemName: "eye.slash")
+                            Image(systemName: "eye.slash.circle.fill")
                                 .foregroundColor(.gray)
                             Text("Hide Indicator".i18n() + ":")
                         }

--- a/Input Source Pro/UI/Components/BrowserRuleRow.swift
+++ b/Input Source Pro/UI/Components/BrowserRuleRow.swift
@@ -2,7 +2,9 @@ import SwiftUI
 
 struct BrowserRuleRow: View {
     @State var showModal = false
-
+    
+    var isSelected: Bool = false
+    
     @ObservedObject var rule: BrowserRule
 
     let imgSize: CGFloat = 16
@@ -15,7 +17,7 @@ struct BrowserRuleRow: View {
 
             if rule.hideIndicator == true {
                 Image(systemName: "eye.slash.circle.fill")
-                    .foregroundColor(.gray)
+                    .opacity(0.7)
                     .frame(width: imgSize, height: imgSize)
             }
 
@@ -23,9 +25,12 @@ struct BrowserRuleRow: View {
                 let symbolName = keyboardRestoreStrategy.systemImageName
                 let color: Color = {
                     switch symbolName {
-                    case "d.circle.fill", "d.square.fill": return .green
-                    case "arrow.uturn.left.circle.fill": return .blue
-                    default: return .primary
+                    case "d.circle.fill", "d.square.fill":
+                        return isSelected ? .primary.opacity(0.7) : .green
+                    case "arrow.uturn.left.circle.fill":
+                        return isSelected ? .primary.opacity(0.7) : .blue
+                    default:
+                        return .primary
                     }
                 }()
                 Image(systemName: symbolName)

--- a/Input Source Pro/UI/Components/BrowserRuleRow.swift
+++ b/Input Source Pro/UI/Components/BrowserRuleRow.swift
@@ -14,7 +14,7 @@ struct BrowserRuleRow: View {
             Spacer()
 
             if rule.hideIndicator == true {
-                Image(systemName: "eye.slash")
+                Image(systemName: "eye.slash.circle.fill")
                     .foregroundColor(.gray)
                     .frame(width: imgSize, height: imgSize)
             }
@@ -23,14 +23,13 @@ struct BrowserRuleRow: View {
                 let symbolName = keyboardRestoreStrategy.systemImageName
                 let color: Color = {
                     switch symbolName {
-                    case "d.circle", "d.square.fill": return .green
-                    case "arrow.counterclockwise": return .blue
+                    case "d.circle.fill", "d.square.fill": return .green
+                    case "arrow.uturn.left.circle.fill": return .blue
                     default: return .primary
                     }
                 }()
                 Image(systemName: symbolName)
                     .foregroundColor(color)
-                    .font(.system(size: imgSize - 4))
                     .frame(width: imgSize, height: imgSize)
             }
 

--- a/Input Source Pro/UI/Components/PromotionBadge.swift
+++ b/Input Source Pro/UI/Components/PromotionBadge.swift
@@ -16,17 +16,8 @@ struct PromotionBadge: View {
                     Label {
                         Text("Share with friends".i18n())
                     } icon: {
-                        if #available(macOS 15.0, *) {
-                            Image(systemName: "square.and.arrow.up.fill")
-                                .symbolRenderingMode(.palette)
-                                .foregroundStyle(.primary, .blue)
-                                .symbolEffect(.bounce.down.byLayer, options: .repeat(.periodic(delay: 1)))
-                        } else {
-                            Image(systemName: "square.and.arrow.up.fill")
-                                .foregroundColor(.blue)
-                        }
-                        
-                    }
+                        Image(systemName: "square.and.arrow.up.fill")
+                            .foregroundColor(.blue)                    }
                 }
                 
                 Button(action: {
@@ -35,14 +26,8 @@ struct PromotionBadge: View {
                     Label {
                         Text("Star on GitHub".i18n())
                     } icon: {
-                        if #available(macOS 15.0, *) {
-                            Image(systemName: "star.fill")
-                                .symbolRenderingMode(.multicolor)
-                                .symbolEffect(.bounce.down.byLayer, options: .repeat(.periodic(delay: 1)))
-                        } else {
-                            Image(systemName: "star.fill")
-                                .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.0))
-                        }
+                        Image(systemName: "star.fill")
+                            .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.0))
                     }
                 }
                 
@@ -52,14 +37,8 @@ struct PromotionBadge: View {
                     Label {
                         Text("Sponsor".i18n())
                     } icon: {
-                        if #available(macOS 15.0, *) {
-                            Image(systemName: "heart.fill")
-                                .symbolRenderingMode(.multicolor)
-                                .symbolEffect(.bounce.down.byLayer, options: .repeat(.periodic(delay: 1)))
-                        } else {
-                            Image(systemName: "heart.fill")
-                                .foregroundColor(.pink)
-                        }
+                        Image(systemName: "heart.fill")
+                            .foregroundColor(.pink)
                     }
                 }
             }

--- a/Input Source Pro/UI/Components/PromotionBadge.swift
+++ b/Input Source Pro/UI/Components/PromotionBadge.swift
@@ -16,8 +16,16 @@ struct PromotionBadge: View {
                     Label {
                         Text("Share with friends".i18n())
                     } icon: {
-                        Image(systemName: "square.and.arrow.up.fill")
-                            .foregroundColor(.blue)
+                        if #available(macOS 15.0, *) {
+                            Image(systemName: "square.and.arrow.up.fill")
+                                .symbolRenderingMode(.palette)
+                                .foregroundStyle(.primary, .blue)
+                                .symbolEffect(.bounce.down.byLayer, options: .repeat(.periodic(delay: 1)))
+                        } else {
+                            Image(systemName: "square.and.arrow.up.fill")
+                                .foregroundColor(.blue)
+                        }
+                        
                     }
                 }
                 
@@ -27,8 +35,14 @@ struct PromotionBadge: View {
                     Label {
                         Text("Star on GitHub".i18n())
                     } icon: {
-                        Image(systemName: "star.fill")
-                            .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.0))
+                        if #available(macOS 15.0, *) {
+                            Image(systemName: "star.fill")
+                                .symbolRenderingMode(.multicolor)
+                                .symbolEffect(.bounce.down.byLayer, options: .repeat(.periodic(delay: 1)))
+                        } else {
+                            Image(systemName: "star.fill")
+                                .foregroundColor(Color(red: 1.0, green: 0.84, blue: 0.0))
+                        }
                     }
                 }
                 
@@ -38,8 +52,14 @@ struct PromotionBadge: View {
                     Label {
                         Text("Sponsor".i18n())
                     } icon: {
-                        Image(systemName: "heart.fill")
-                            .foregroundColor(.pink)
+                        if #available(macOS 15.0, *) {
+                            Image(systemName: "heart.fill")
+                                .symbolRenderingMode(.multicolor)
+                                .symbolEffect(.bounce.down.byLayer, options: .repeat(.periodic(delay: 1)))
+                        } else {
+                            Image(systemName: "heart.fill")
+                                .foregroundColor(.pink)
+                        }
                     }
                 }
             }

--- a/Input Source Pro/UI/Components/PromotionBadge.swift
+++ b/Input Source Pro/UI/Components/PromotionBadge.swift
@@ -17,7 +17,8 @@ struct PromotionBadge: View {
                         Text("Share with friends".i18n())
                     } icon: {
                         Image(systemName: "square.and.arrow.up.fill")
-                            .foregroundColor(.blue)                    }
+                            .foregroundColor(.blue)
+                    }
                 }
                 
                 Button(action: {

--- a/Input Source Pro/UI/Components/RulesApplicationDetail.swift
+++ b/Input Source Pro/UI/Components/RulesApplicationDetail.swift
@@ -60,9 +60,8 @@ struct ApplicationDetail: View {
                     .fontWeight(.medium)
 
                 HStack {
-                    Image(systemName: "d.circle")
+                    Image(systemName: "d.circle.fill")
                         .foregroundColor(.green)
-                        .frame(width: 20, height: 20, alignment: .center)
                     NSToggleView(
                         label: restoreStrategyName(strategy: .UseDefaultKeyboardInstead),
                         state: preferencesVM.preferences.isRestorePreviouslyUsedInputSource
@@ -75,9 +74,8 @@ struct ApplicationDetail: View {
                 }
 
                 HStack {
-                    Image(systemName: "arrow.counterclockwise")
+                    Image(systemName: "arrow.uturn.left.circle.fill")
                         .foregroundColor(.blue)
-                        .frame(width: 20, height: 20, alignment: .center)
                     NSToggleView(
                         label: restoreStrategyName(strategy: .RestorePreviouslyUsedOne),
                         state: preferencesVM.preferences.isRestorePreviouslyUsedInputSource
@@ -97,9 +95,8 @@ struct ApplicationDetail: View {
                 Text("Indicator".i18n())
                     .fontWeight(.medium)
                 HStack {
-                    Image(systemName: "eye.slash")
+                    Image(systemName: "eye.slash.circle.fill")
                         .foregroundColor(.gray)
-                        .frame(width: 20, height: 20, alignment: .center)
                     NSToggleView(
                         label: "Hide Indicator".i18n(),
                         state: hideIndicator,

--- a/Input Source Pro/UI/Components/RulesApplicationPicker.swift
+++ b/Input Source Pro/UI/Components/RulesApplicationPicker.swift
@@ -31,7 +31,7 @@ struct ApplicationPicker: View {
                     Spacer()
 
                     if app.hideIndicator {
-                        SwiftUI.Image(systemName: "eye.slash")
+                        SwiftUI.Image(systemName: "eye.slash.circle.fill")
                             .foregroundColor(.gray)
                     }
 
@@ -42,15 +42,13 @@ struct ApplicationPicker: View {
 
                     if preferencesVM.preferences.isRestorePreviouslyUsedInputSource {
                         if app.doNotRestoreKeyboard {
-                            SwiftUI.Image(systemName: "d.circle")
+                            SwiftUI.Image(systemName: "d.circle.fill")
                                 .foregroundColor(.green)
-                                .offset(x: 0, y: -1.5)
                         }
                     } else {
                         if app.doRestoreKeyboard {
-                            SwiftUI.Image(systemName: "arrow.counterclockwise")
+                            SwiftUI.Image(systemName: "arrow.uturn.left.circle.fill")
                                 .foregroundColor(.blue)
-                                .offset(x: 0, y: -1)
                         }
                     }
 

--- a/Input Source Pro/UI/Components/RulesApplicationPicker.swift
+++ b/Input Source Pro/UI/Components/RulesApplicationPicker.swift
@@ -32,7 +32,7 @@ struct ApplicationPicker: View {
 
                     if app.hideIndicator {
                         SwiftUI.Image(systemName: "eye.slash.circle.fill")
-                            .foregroundColor(.gray)
+                            .opacity(0.7)
                     }
 
                     if preferencesVM.needDisplayEnhancedModePrompt(bundleIdentifier: app.bundleId) {
@@ -43,12 +43,14 @@ struct ApplicationPicker: View {
                     if preferencesVM.preferences.isRestorePreviouslyUsedInputSource {
                         if app.doNotRestoreKeyboard {
                             SwiftUI.Image(systemName: "d.circle.fill")
-                                .foregroundColor(.green)
+                                .foregroundColor(selectedApp.contains(app) ? .primary : .green)
+                                .opacity(selectedApp.contains(app) ? 0.7 : 1.0)
                         }
                     } else {
                         if app.doRestoreKeyboard {
                             SwiftUI.Image(systemName: "arrow.uturn.left.circle.fill")
-                                .foregroundColor(.blue)
+                                .foregroundColor(selectedApp.contains(app) ? .primary : .blue)
+                                .opacity(selectedApp.contains(app) ? 0.7 : 1.0)
                         }
                     }
 

--- a/Input Source Pro/UI/Screens/BrowserRulesSettingsView.swift
+++ b/Input Source Pro/UI/Screens/BrowserRulesSettingsView.swift
@@ -55,7 +55,7 @@ struct BrowserRulesSettingsView: View {
             .border(width: 1, edges: [.bottom], color: NSColor.border.color)
 
             List(browserRules, id: \.self, selection: $selectedRules) { rule in
-                BrowserRuleRow(rule: rule)
+                BrowserRuleRow(isSelected: selectedRules.contains(rule), rule: rule)
             }
 
             HStack(spacing: 0) {

--- a/Input Source Pro/Utilities/KeyboardRestoreStrategy.swift
+++ b/Input Source Pro/Utilities/KeyboardRestoreStrategy.swift
@@ -16,9 +16,9 @@ enum KeyboardRestoreStrategy: String, CaseIterable, Identifiable {
     var systemImageName: String {
         switch self {
         case .UseDefaultKeyboardInstead:
-            return "d.circle"
+            return "d.circle.fill"
         case .RestorePreviouslyUsedOne:
-            return "arrow.counterclockwise"
+            return "arrow.uturn.left.circle.fill"
         }
     }
 


### PR DESCRIPTION
This pull request focuses on improving the visual consistency of icons across the application and introducing conditional styling based on selection states. Changes include updating system image names for icons, adding opacity adjustments, and modifying color behaviors based on selection.

### Icon Updates for Visual Consistency:
* [`BrowserRuleEditView.swift`](diffhunk://#diff-56be31ed01cbc20ff1933594896e37912489e1d336639beb60530afa8353eb75L163-R163): Updated the "Hide Indicator" icon from `eye.slash` to `eye.slash.circle.fill` for a more consistent and modern appearance.
* [`RulesApplicationDetail.swift`](diffhunk://#diff-1662c37517ed2f693f20a2e1f684cd3df4f4494be4ba7b265b50860b660553a1L63-L65): Changed `d.circle` to `d.circle.fill` and `arrow.counterclockwise` to `arrow.uturn.left.circle.fill` for keyboard restore strategy icons, aligning them with updated system image names. [[1]](diffhunk://#diff-1662c37517ed2f693f20a2e1f684cd3df4f4494be4ba7b265b50860b660553a1L63-L65) [[2]](diffhunk://#diff-1662c37517ed2f693f20a2e1f684cd3df4f4494be4ba7b265b50860b660553a1L78-L80) [[3]](diffhunk://#diff-1662c37517ed2f693f20a2e1f684cd3df4f4494be4ba7b265b50860b660553a1L100-L102)
* [`KeyboardRestoreStrategy.swift`](diffhunk://#diff-d302eccd202c78ad4e10936d1c26570ec4f2da1e6ee09ec0c174d0fe45e14af1L19-R21): Updated the `systemImageName` mappings for `KeyboardRestoreStrategy` enum to reflect the new icon names (`d.circle.fill` and `arrow.uturn.left.circle.fill`).

### Conditional Styling Based on Selection:
* [`BrowserRuleRow.swift`](diffhunk://#diff-03ca9e9274d79318f7246c31ab0723116512f027cca7e5095b5f6ff28d730a9dR6-R7): Introduced `isSelected` property to conditionally adjust icon colors and opacity (e.g., `d.circle.fill` and `arrow.uturn.left.circle.fill` now change appearance when selected). [[1]](diffhunk://#diff-03ca9e9274d79318f7246c31ab0723116512f027cca7e5095b5f6ff28d730a9dR6-R7) [[2]](diffhunk://#diff-03ca9e9274d79318f7246c31ab0723116512f027cca7e5095b5f6ff28d730a9dL17-L33)
* [`RulesApplicationPicker.swift`](diffhunk://#diff-9f3ffd4e18a412dc1e9d2245041e3bf0e06b9079f2c1689e9f9217a4f7ae0f29L34-R35): Adjusted icons (`eye.slash.circle.fill`, `d.circle.fill`, and `arrow.uturn.left.circle.fill`) to change color and opacity based on whether the application is selected. [[1]](diffhunk://#diff-9f3ffd4e18a412dc1e9d2245041e3bf0e06b9079f2c1689e9f9217a4f7ae0f29L34-R35) [[2]](diffhunk://#diff-9f3ffd4e18a412dc1e9d2245041e3bf0e06b9079f2c1689e9f9217a4f7ae0f29L45-R53)
* [`BrowserRulesSettingsView.swift`](diffhunk://#diff-42728856290e6d84a6e763a4c0909f5e4d3b864d91ee82ee72e1a2835536f42cL58-R58): Passed `isSelected` property to `BrowserRuleRow` to enable conditional styling based on selection state.