### PR TITLE
feat: add support for Dia browser across enums, preferences, and UI logic

### DIFF
--- a/Input Source Pro/Models/PreferencesVM+BrowserAddress.swift
+++ b/Input Source Pro/Models/PreferencesVM+BrowserAddress.swift
@@ -98,7 +98,7 @@ enum BrowserThatCanWatchBrowserAddressFocus: CaseIterable {
         return nil
     }
 
-    case Safari, SafariTechnologyPreview, Chrome, Chromium, Brave, BraveBeta, BraveNightly, Edge, Vivaldi, Arc, Opera, Firefox, FirefoxNightly, FirefoxDeveloperEdition, Zen
+    case Safari, SafariTechnologyPreview, Chrome, Chromium, Brave, BraveBeta, BraveNightly, Edge, Vivaldi, Arc, Opera, Firefox, FirefoxNightly, FirefoxDeveloperEdition, Zen, Dia
 
     var bundleIdentifier: String {
         return browser.rawValue
@@ -136,6 +136,8 @@ enum BrowserThatCanWatchBrowserAddressFocus: CaseIterable {
             return .FirefoxDeveloperEdition
         case .Zen:
             return .Zen
+        case .Dia:
+            return .Dia
         }
     }
 
@@ -157,7 +159,7 @@ enum BrowserThatCanWatchBrowserAddressFocus: CaseIterable {
         case .Opera:
             return focusedElement.domClassList().contains("AddressTextfieldView")
 
-        case .Chromium, .Chrome, .Brave, .BraveBeta, .BraveNightly, .Edge:
+        case .Chromium, .Chrome, .Brave, .BraveBeta, .BraveNightly, .Edge, .Dia:
             if focusedElement.domClassList().contains("OmniboxViewViews") {
                 if let description = focusedElement.safeString(attribute: .description),
                    chromiumSearchBarDescMap[description] == true

--- a/Input Source Pro/Models/PreferencesVM+BrowserRule.swift
+++ b/Input Source Pro/Models/PreferencesVM+BrowserRule.swift
@@ -119,6 +119,8 @@ extension PreferencesVM {
             return preferences.isEnableURLSwitchForFirefoxNightly
         case .Zen:
             return preferences.isEnableURLSwitchForZen
+        case .Dia:
+            return preferences.isEnableURLSwitchForDia
         }
     }
 

--- a/Input Source Pro/Models/PreferencesVM.swift
+++ b/Input Source Pro/Models/PreferencesVM.swift
@@ -189,6 +189,8 @@ extension PreferencesVM {
             guard preferences.isEnableURLSwitchForFirefoxNightly else { return nil }
         case .Zen:
             guard preferences.isEnableURLSwitchForZen else { return nil }
+        case .Dia:
+            guard preferences.isEnableURLSwitchForDia else { return nil }
         }
 
         if let application = application,
@@ -256,6 +258,7 @@ struct Preferences {
         static let isEnableURLSwitchForFirefoxDeveloperEdition = "isEnableURLSwitchForFirefoxDeveloperEdition"
         static let isEnableURLSwitchForFirefoxNightly = "isEnableURLSwitchForFirefoxNightly"
         static let isEnableURLSwitchForZen = "isEnableURLSwitchForZen"
+        static let isEnableURLSwitchForDia = "isEnableURLSwitchForDia"
 
         static let isAutoAppearanceMode = "isAutoAppearanceMode"
         static let appearanceMode = "appearanceMode"
@@ -377,6 +380,9 @@ struct Preferences {
 
     @UserDefault(Preferences.Key.isEnableURLSwitchForZen)
     var isEnableURLSwitchForZen = false
+    
+    @UserDefault(Preferences.Key.isEnableURLSwitchForDia)
+    var isEnableURLSwitchForDia = false
 
     // MARK: - Appearance
 

--- a/Input Source Pro/UI/Screens/BrowserRulesSettingsView.swift
+++ b/Input Source Pro/UI/Screens/BrowserRulesSettingsView.swift
@@ -177,6 +177,8 @@ struct BrowserRulesSettingsView: View {
                 $0.isEnableURLSwitchForFirefoxNightly = isEnable
             case .Zen:
                 $0.isEnableURLSwitchForZen = isEnable
+            case .Dia:
+                $0.isEnableURLSwitchForDia = isEnable
             }
         }
     }

--- a/Input Source Pro/Utilities/BrowserURL.swift
+++ b/Input Source Pro/Utilities/BrowserURL.swift
@@ -19,6 +19,7 @@ enum Browser: String, CaseIterable {
     case FirefoxDeveloperEdition = "org.mozilla.firefoxdeveloperedition"
     case FirefoxNightly = "org.mozilla.nightly"
     case Zen = "app.zen-browser.zen"
+    case Dia = "company.thebrowser.dia"
 
     var displayName: String {
         switch self {
@@ -54,6 +55,8 @@ enum Browser: String, CaseIterable {
             return "Firefox Nightly"
         case .Zen:
             return "Zen"
+        case .Dia:
+            return "Dia"
         }
     }
 }


### PR DESCRIPTION
This pull request introduces support for a new browser, "Dia," across various components of the application. The changes primarily involve adding "Dia" to enums, preferences, and UI logic to ensure seamless integration.
Resolves #35

### Browser support updates:

* [`Input Source Pro/Models/PreferencesVM+BrowserAddress.swift`](diffhunk://#diff-a7ff0b7cc0489a8cf7f259481bcfa59dcb3ee5ebd6a815eb0539dfafb7a46231L101-R101): Added "Dia" to the `BrowserThatCanWatchBrowserAddressFocus` enum and updated logic to handle its specific behavior when focusing on browser address fields. [[1]](diffhunk://#diff-a7ff0b7cc0489a8cf7f259481bcfa59dcb3ee5ebd6a815eb0539dfafb7a46231L101-R101) [[2]](diffhunk://#diff-a7ff0b7cc0489a8cf7f259481bcfa59dcb3ee5ebd6a815eb0539dfafb7a46231R139-R140) [[3]](diffhunk://#diff-a7ff0b7cc0489a8cf7f259481bcfa59dcb3ee5ebd6a815eb0539dfafb7a46231L160-R162)

### Preferences integration:

* [`Input Source Pro/Models/PreferencesVM.swift`](diffhunk://#diff-22b560d011019703ac3e8e4cd0b632e6de32670f20ab59cbe22257cce8ca21c7R192-R193): Added support for enabling/disabling URL switching for "Dia" through new preferences keys and properties. [[1]](diffhunk://#diff-22b560d011019703ac3e8e4cd0b632e6de32670f20ab59cbe22257cce8ca21c7R192-R193) [[2]](diffhunk://#diff-22b560d011019703ac3e8e4cd0b632e6de32670f20ab59cbe22257cce8ca21c7R261) [[3]](diffhunk://#diff-22b560d011019703ac3e8e4cd0b632e6de32670f20ab59cbe22257cce8ca21c7R384-R386)

### UI updates:

* [`Input Source Pro/UI/Screens/BrowserRulesSettingsView.swift`](diffhunk://#diff-42728856290e6d84a6e763a4c0909f5e4d3b864d91ee82ee72e1a2835536f42cR180-R181): Updated the browser rules settings view to allow toggling URL switching for "Dia."

### Browser enum updates:

* [`Input Source Pro/Utilities/BrowserURL.swift`](diffhunk://#diff-c33c1233ed35660e09bb97afcd5a7c4b894d11f6c69fe9652c7d373a4c2eaf90R22): Added "Dia" to the `Browser` enum with its bundle identifier and display name. [[1]](diffhunk://#diff-c33c1233ed35660e09bb97afcd5a7c4b894d11f6c69fe9652c7d373a4c2eaf90R22) [[2]](diffhunk://#diff-c33c1233ed35660e09bb97afcd5a7c4b894d11f6c69fe9652c7d373a4c2eaf90R58-R59)

### Known Issues

- When switching tabs, the focus will default to the Sidebar or Floating chat window. It is currently unclear whether this will cause any issues.
- I am not currently using the Dia browser myself, so this implementation may not be continuously maintained.