### PR TITLE
fix: support Dia browser in Browser Rules

### DIFF
--- a/Input Source Pro/Utilities/AppKit/NSApplication.swift
+++ b/Input Source Pro/Utilities/AppKit/NSApplication.swift
@@ -76,7 +76,17 @@ extension NSApplication {
     static func isBrowserApp(_ bundleIdentifier: String?) -> Bool {
         guard let bundleIdentifier = bundleIdentifier else { return false }
 
-        return browserAppIdentifier.contains(bundleIdentifier)
+        if browserAppIdentifier.contains(bundleIdentifier) {
+            return true
+        }
+
+        if Browser(rawValue: bundleIdentifier) != nil,
+           NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier) != nil
+        {
+            return true
+        }
+
+        return false
     }
 
     static func isBrowserInstalled(_ bundleIdentifier: String) -> Bool {


### PR DESCRIPTION
## Problem Description

The "Browser Rules UI" currently hides browser toggles based on the return value of ⁠NSApplication.isBrowserInstalled. This helper function exclusively checks the LaunchServices registry for the "html/https handler" set.
For newly integrated browsers, such as Dia, if they are installed by the user before completing this specific LaunchServices registration step, ⁠isBrowserInstalled will incorrectly return ⁠false. Consequently, the configuration toggle for "Dia" remains hidden in the UI, preventing users from selecting it as their default browser, even though the application is successfully installed and functional. This limitation restricts user choice and hinders the adoption of new browsers on our platform.

## Solution

This PR refines the detection logic within the ⁠isBrowserApp helper function by introducing a more robust fallback mechanism:

1. Bundle ID Check: First, it verifies if the application's Bundle ID matches one of our supported browsers as defined in the ⁠Browser enum. 
2. Application Existence Confirmation: Second, it uses ⁠NSWorkspace.shared.urlForApplication to confirm that the application actually exists on the user's system.

If both of these conditions are met, the browser is treated as installed.
This update preserves the original LaunchServices check as the primary detection method, ensuring backward compatibility with already registered browsers. The new fallback logic is only invoked when the primary check does not yield a match, thereby avoiding any impact on existing functionality and successfully unlocking the UI toggle for "Dia".
