### PR TITLE
feat: add support for ChatGPT Atlas browser

### DIFF
--- a/Input Source Pro/Models/PreferencesVM+BrowserAddress.swift
+++ b/Input Source Pro/Models/PreferencesVM+BrowserAddress.swift
@@ -98,7 +98,7 @@ enum BrowserThatCanWatchBrowserAddressFocus: CaseIterable {
         return nil
     }
 
-    case Safari, SafariTechnologyPreview, Chrome, Chromium, Brave, BraveBeta, BraveNightly, Edge, Vivaldi, Arc, Opera, Firefox, FirefoxNightly, FirefoxDeveloperEdition, Zen, Dia
+    case Safari, SafariTechnologyPreview, Chrome, Chromium, Brave, BraveBeta, BraveNightly, Edge, Vivaldi, Arc, Opera, Firefox, FirefoxNightly, FirefoxDeveloperEdition, Zen, Dia, Atlas
 
     var bundleIdentifier: String {
         return browser.rawValue
@@ -138,6 +138,8 @@ enum BrowserThatCanWatchBrowserAddressFocus: CaseIterable {
             return .Zen
         case .Dia:
             return .Dia
+        case .Atlas:
+            return .Atlas
         }
     }
 
@@ -159,7 +161,7 @@ enum BrowserThatCanWatchBrowserAddressFocus: CaseIterable {
         case .Opera:
             return focusedElement.domClassList().contains("AddressTextfieldView")
 
-        case .Chromium, .Chrome, .Brave, .BraveBeta, .BraveNightly, .Edge, .Dia:
+        case .Chromium, .Chrome, .Brave, .BraveBeta, .BraveNightly, .Edge, .Dia, .Atlas:
             if focusedElement.domClassList().contains("OmniboxViewViews") {
                 if let description = focusedElement.safeString(attribute: .description),
                    chromiumSearchBarDescMap[description] == true

--- a/Input Source Pro/Models/PreferencesVM+BrowserRule.swift
+++ b/Input Source Pro/Models/PreferencesVM+BrowserRule.swift
@@ -121,6 +121,8 @@ extension PreferencesVM {
             return preferences.isEnableURLSwitchForZen
         case .Dia:
             return preferences.isEnableURLSwitchForDia
+        case .Atlas:
+            return preferences.isEnableURLSwitchForAtlas
         }
     }
 

--- a/Input Source Pro/Models/PreferencesVM.swift
+++ b/Input Source Pro/Models/PreferencesVM.swift
@@ -176,11 +176,18 @@ extension PreferencesVM {
             guard preferences.isEnableURLSwitchForZen else { return nil }
         case .Dia:
             guard preferences.isEnableURLSwitchForDia else { return nil }
+        case .Atlas:
+            guard preferences.isEnableURLSwitchForAtlas else { return nil }
         }
 
         if let application = application,
            let focusedWindow: UIElement = try? application.attribute(.focusedWindow),
-           let url = browser.getCurrentTabURL(focusedWindow: focusedWindow)
+           let url = {
+               if browser == .Atlas {
+                   browser.registerAtlasAddressBarObserver(application: application, focusedWindow: focusedWindow)
+               }
+               return browser.getCurrentTabURL(focusedWindow: focusedWindow)
+           }()
         {
             return url
         } else {
@@ -244,6 +251,7 @@ struct Preferences {
         static let isEnableURLSwitchForFirefoxNightly = "isEnableURLSwitchForFirefoxNightly"
         static let isEnableURLSwitchForZen = "isEnableURLSwitchForZen"
         static let isEnableURLSwitchForDia = "isEnableURLSwitchForDia"
+        static let isEnableURLSwitchForAtlas = "isEnableURLSwitchForAtlas"
 
         static let isAutoAppearanceMode = "isAutoAppearanceMode"
         static let appearanceMode = "appearanceMode"
@@ -363,6 +371,9 @@ struct Preferences {
     
     @UserDefault(Preferences.Key.isEnableURLSwitchForDia)
     var isEnableURLSwitchForDia = false
+
+    @UserDefault(Preferences.Key.isEnableURLSwitchForAtlas)
+    var isEnableURLSwitchForAtlas = false
 
     // MARK: - Appearance
 

--- a/Input Source Pro/UI/Screens/BrowserRulesSettingsView.swift
+++ b/Input Source Pro/UI/Screens/BrowserRulesSettingsView.swift
@@ -179,6 +179,8 @@ struct BrowserRulesSettingsView: View {
                 $0.isEnableURLSwitchForZen = isEnable
             case .Dia:
                 $0.isEnableURLSwitchForDia = isEnable
+            case .Atlas:
+                $0.isEnableURLSwitchForAtlas = isEnable
             }
         }
     }

--- a/Input Source Pro/Utilities/BrowserURL.swift
+++ b/Input Source Pro/Utilities/BrowserURL.swift
@@ -1,6 +1,90 @@
 import AppKit
 import AXSwift
 
+private var atlasAddressBarCachedURL: URL?
+private var atlasAddressBarObserver: Observer?
+private var atlasAddressBarElement: AXUIElement?
+
+private func atlasURLFromAddressBarValue(_ value: String) -> URL? {
+    let newtabMarkers = [
+        "favorites://",
+        "edge://newtab/",
+        "chrome://newtab/",
+        "chrome://new-tab-page/",
+        "chrome://vivaldi-webui/",
+        "about:newtab", // Firefox
+    ]
+
+    let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        .trimmingCharacters(in: CharacterSet(charactersIn: ","))
+
+    guard !trimmed.isEmpty else { return nil }
+
+    if let url = URL(string: trimmed), url.scheme != nil {
+        if newtabMarkers.contains(where: { url.absoluteString.contains($0) }) {
+            return .newtab
+        }
+        return url
+    }
+
+    if !trimmed.contains(" "),
+       (trimmed.contains(".") || trimmed.contains(":") || trimmed == "localhost"),
+       let url = URL(string: "https://\(trimmed)")
+    {
+        if newtabMarkers.contains(where: { url.absoluteString.contains($0) }) {
+            return .newtab
+        }
+        return url
+    }
+
+    return nil
+}
+
+private func updateAtlasCachedURL(from value: String) {
+    if let url = atlasURLFromAddressBarValue(value) {
+        atlasAddressBarCachedURL = url
+    }
+}
+
+private func findAtlasAddressBarElement(in root: UIElement) -> UIElement? {
+    var stack: [UIElement] = [root]
+
+    while let element = stack.popLast() {
+        if let role = try? element.role(), role.rawValue == "AXWebArea" {
+            continue
+        }
+
+        if let role = try? element.role(),
+           role == .textField || role == .textArea || role == .comboBox,
+           let value = element.safeString(attribute: .value),
+           atlasURLFromAddressBarValue(value) != nil
+        {
+            return element
+        }
+
+        stack.append(contentsOf: fetchChildren(of: element))
+    }
+
+    return nil
+}
+
+private func fetchChildren(of element: UIElement) -> [UIElement] {
+    let role = try? element.role()
+    let rawElementsOptional: [AXUIElement]? = {
+        if role == .table || role == .outline {
+            return try? element.attribute(.visibleRows)
+        }
+
+        return try? element.attribute(.children)
+    }()
+
+    guard let rawElements = rawElementsOptional else {
+        return []
+    }
+
+    return rawElements.map(UIElement.init)
+}
+
 // Update BrowserThatCanWatchBrowserAddressFocus as well
 enum Browser: String, CaseIterable {
     case Safari = "com.apple.Safari"
@@ -20,6 +104,7 @@ enum Browser: String, CaseIterable {
     case FirefoxNightly = "org.mozilla.nightly"
     case Zen = "app.zen-browser.zen"
     case Dia = "company.thebrowser.dia"
+    case Atlas = "com.openai.atlas"
 
     var displayName: String {
         switch self {
@@ -57,16 +142,90 @@ enum Browser: String, CaseIterable {
             return "Zen"
         case .Dia:
             return "Dia"
+        case .Atlas:
+            return "ChatGPT Atlas"
         }
     }
 }
 
 extension Browser {
+    func registerAtlasAddressBarObserver(application: Application?, focusedWindow: UIElement) {
+        guard self == .Atlas, let application = application else { return }
+        guard let addressBarElement = findAtlasAddressBarElement(in: focusedWindow) else { return }
+
+        let rawElement = addressBarElement.element
+        if let cachedElement = atlasAddressBarElement,
+           CFEqual(cachedElement, rawElement)
+        {
+            return
+        }
+
+        atlasAddressBarObserver?.stop()
+        atlasAddressBarElement = rawElement
+
+        atlasAddressBarObserver = application.createObserver { _, element, notification in
+            guard notification == .valueChanged,
+                  let value = element.safeString(attribute: .value)
+            else { return }
+
+            updateAtlasCachedURL(from: value)
+        }
+
+        if let value = addressBarElement.safeString(attribute: .value) {
+            updateAtlasCachedURL(from: value)
+        }
+
+        try? atlasAddressBarObserver?.addNotification(.valueChanged, forElement: addressBarElement)
+    }
+
     func getCurrentTabURL(focusedWindow: UIElement) -> URL? {
+        if self == .Atlas,
+           let focusedElement: UIElement = try? focusedWindow.attribute(.focusedUIElement),
+           let value = focusedElement.safeString(attribute: .value)
+        {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: ","))
+            if !trimmed.isEmpty {
+                if let url = URL(string: trimmed), url.scheme != nil {
+                    return url
+                }
+                if !trimmed.contains(" "),
+                   (trimmed.contains(".") || trimmed.contains(":") || trimmed == "localhost"),
+                   let url = URL(string: "https://\(trimmed)")
+                {
+                    return url
+                }
+            }
+        }
+
+        if self == .Atlas,
+           let focusedElement: UIElement = try? systemWideElement.attribute(.focusedUIElement),
+           let value = focusedElement.safeString(attribute: .value)
+        {
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: CharacterSet(charactersIn: ","))
+            if !trimmed.isEmpty {
+                if let url = URL(string: trimmed), url.scheme != nil {
+                    return url
+                }
+                if !trimmed.contains(" "),
+                   (trimmed.contains(".") || trimmed.contains(":") || trimmed == "localhost"),
+                   let url = URL(string: "https://\(trimmed)")
+                {
+                    return url
+                }
+            }
+        }
+
         guard let windowElement = Element.initialize(rawElement: focusedWindow.element),
               let webArea = (try? QueryWebAreaService(windowElement: windowElement).perform()),
               let url = webArea.url
-        else { return nil }
+        else {
+            if self == .Atlas, let cachedURL = atlasAddressBarCachedURL {
+                return cachedURL
+            }
+            return nil
+        }
 
         if [
             "favorites://",


### PR DESCRIPTION
- Add Atlas browser to Browser enum with bundle ID 'com.openai.atlas'
- Implement Atlas address bar observer to monitor URL changes via Accessibility API
- Add URL parsing logic for Atlas since it lacks AXWebArea support
- Add 'isEnableURLSwitchForAtlas' preference setting
- Update browser rules UI to include Atlas toggle
- Integrate Atlas support into existing browser URL switching workflow

This enables automatic input source switching based on URL for ChatGPT Atlas browser, similar to other supported browsers.