### PR TITLE
feat: add option to trigger shortcuts on key press

### DIFF
--- a/Input Source Pro/Models/PreferencesVM.swift
+++ b/Input Source Pro/Models/PreferencesVM.swift
@@ -254,6 +254,7 @@ struct Preferences {
         static let singleModifierTriggerGroupMapping = "singleModifierTriggerGroupMapping"
         static let singleModifierInputSourceMapping = "singleModifierInputSourceMapping"
         static let singleModifierGroupMapping = "singleModifierGroupMapping"
+        static let isShortcutTriggerOnKeyDown = "isShortcutTriggerOnKeyDown"
 
         static let isAutoAppearanceMode = "isAutoAppearanceMode"
         static let appearanceMode = "appearanceMode"
@@ -346,6 +347,9 @@ struct Preferences {
 
     @CodableUserDefault(Preferences.Key.singleModifierGroupMapping)
     var singleModifierGroupMapping = [String: ModifierCombo]()
+
+    @UserDefault(Preferences.Key.isShortcutTriggerOnKeyDown)
+    var isShortcutTriggerOnKeyDown = false
 
     // MARK: - App Rules
 

--- a/Input Source Pro/Resources/en.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/en.lproj/Localizable.strings
@@ -215,3 +215,6 @@
 "Open Input Monitoring Settings" = "Open Input Monitoring Settings";
 "Open Input Monitoring Settings, click the \"+\" button and add \"Input Source Pro\" to the list." = "Open Input Monitoring Settings, click the \"+\" button and add \"Input Source Pro\" to the list.";
 "Disabled until permissions are granted" = "Disabled until permissions are granted";
+
+"Trigger on Key Press" = "Trigger on Key Press";
+"Trigger on Key Press Description" = "When enabled, shortcuts trigger immediately when keys are pressed. When disabled, shortcuts trigger when keys are released.";

--- a/Input Source Pro/Resources/ja.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/ja.lproj/Localizable.strings
@@ -215,3 +215,6 @@
 "Open Input Monitoring Settings" = "入力監視設定を開く";
 "Open Input Monitoring Settings, click the \"+\" button and add \"Input Source Pro\" to the list." = "入力監視設定を開き、「+」ボタンをクリックして一覧に「Input Source Pro」を追加してください。";
 "Disabled until permissions are granted" = "権限が付与されるまで無効";
+
+"Trigger on Key Press" = "キーを押したときにトリガー";
+"Trigger on Key Press Description" = "有効にすると、キーを押した瞬間にショートカットがトリガーされます。無効にすると、キーを離したときにトリガーされます。";

--- a/Input Source Pro/Resources/ko.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/ko.lproj/Localizable.strings
@@ -215,3 +215,6 @@
 "Open Input Monitoring Settings" = "입력 모니터링 설정 열기";
 "Open Input Monitoring Settings, click the \"+\" button and add \"Input Source Pro\" to the list." = "입력 모니터링 설정을 열고 \"+\" 버튼을 클릭한 다음 목록에 \"Input Source Pro\"를 추가하세요.";
 "Disabled until permissions are granted" = "권한이 허용될 때까지 비활성화됨";
+
+"Trigger on Key Press" = "키를 누를 때 트리거";
+"Trigger on Key Press Description" = "활성화하면 키를 누르는 즉시 단축키가 트리거됩니다. 비활성화하면 키를 뗄 때 단축키가 트리거됩니다.";

--- a/Input Source Pro/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/zh-Hans.lproj/Localizable.strings
@@ -217,3 +217,6 @@
 "Open Input Monitoring Settings" = "打开「输入监控」设置";
 "Open Input Monitoring Settings, click the \"+\" button and add \"Input Source Pro\" to the list." = "打开「输入监控」设置，点击“+”按钮并将“Input Source Pro”添加到列表中。";
 "Disabled until permissions are granted" = "权限授予前将被禁用";
+
+"Trigger on Key Press" = "按下时触发";
+"Trigger on Key Press Description" = "启用时，按下按键立即触发快捷键。禁用时，松开按键时触发快捷键。";

--- a/Input Source Pro/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/zh-Hant.lproj/Localizable.strings
@@ -217,3 +217,6 @@
 "Open Input Monitoring Settings" = "打開「輸入監控」設定";
 "Open Input Monitoring Settings, click the \"+\" button and add \"Input Source Pro\" to the list." = "打開「輸入監控」設定，點擊「+」按鈕並將「Input Source Pro」加入列表。";
 "Disabled until permissions are granted" = "權限授予前將被停用";
+
+"Trigger on Key Press" = "按下時觸發";
+"Trigger on Key Press Description" = "啟用時，按下按鍵立即觸發快捷鍵。停用時，放開按鍵時觸發快捷鍵。";

--- a/Input Source Pro/UI/Screens/KeyboardsSettingsView.swift
+++ b/Input Source Pro/UI/Screens/KeyboardsSettingsView.swift
@@ -51,7 +51,8 @@ struct KeyboardsSettingsView: View {
                 if hasSingleModifierShortcuts && (needsAccessibilityPermission || needsInputMonitoringPermission) {
                     permissionWarningSection
                 }
-                
+
+                shortcutOptionsSection
                 normalSection
                 groupSection
                 AddSwitchingGroupButton(onSelect: preferencesVM.addHotKeyGroup)
@@ -59,6 +60,35 @@ struct KeyboardsSettingsView: View {
             .padding()
         }
         .background(NSColor.background1.color)
+        .toggleStyle(.switch)
+    }
+
+    @ViewBuilder
+    var shortcutOptionsSection: some View {
+        let isShortcutTriggerOnKeyDown = Binding(
+            get: { preferencesVM.preferences.isShortcutTriggerOnKeyDown },
+            set: { newValue in
+                preferencesVM.update { $0.isShortcutTriggerOnKeyDown = newValue }
+                indicatorVM.refreshShortcut()
+            }
+        )
+
+        SettingsSection(title: "") {
+            HStack(alignment: .firstTextBaseline) {
+                Toggle("",
+                    isOn: isShortcutTriggerOnKeyDown
+                )
+                VStack(alignment: .leading, spacing: 6) {
+                  Text("Trigger on Key Press".i18n())
+                  Text(.init("Trigger on Key Press Description".i18n()))
+                      .font(.system(size: 12))
+                      .opacity(0.8)
+                }
+                Spacer()
+            }
+            .padding()
+        }
+        .padding(.bottom)
     }
     
     @ViewBuilder


### PR DESCRIPTION
Add "Trigger on Key Press" option in Hot Keys settings that allows shortcuts to trigger immediately when keys are pressed instead of when released.

This provides faster response for users who prefer immediate input source switching.

  - Add `isShortcutTriggerOnKeyDown` setting to Preferences
  - Update `ShortcutTriggerManager` to support keyDown triggering for both keyboard shortcuts and modifier shortcuts
  - Add toggle UI in Hot Keys settings screen
  - Add localization for EN, KO, JA, ZH-Hans, ZH-Hant. They are AI translated.
  
<img width="892" height="760" alt="Screenshot 2026-01-20 at 4 22 13 PM" src="https://github.com/user-attachments/assets/05a600fc-46c0-4c5a-b85c-4cce8e3a4c04" />

