### PR TITLE
[codex] add Codex terminal input source

### DIFF
--- a/Input Source Pro.xcodeproj/project.pbxproj
+++ b/Input Source Pro.xcodeproj/project.pbxproj
@@ -141,6 +141,7 @@
 		D52E2C57293D31E00017CB7E /* FocusAwareTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52E2C56293D31E00017CB7E /* FocusAwareTextField.swift */; };
 		D56A7CFC28A4D5C0002F356A /* AXSwift+Browser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56A7CFB28A4D5C0002F356A /* AXSwift+Browser.swift */; };
 		D57334262A84B40B00C8438F /* IconMap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57334252A84B40B00C8438F /* IconMap.swift */; };
+		D57400012F69D8A600000001 /* CodexTerminalDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57400002F69D8A600000001 /* CodexTerminalDetector.swift */; };
 		D579258C2A1AB0A4003B83EA /* NSRunningApplication+WindowInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D579258B2A1AB0A4003B83EA /* NSRunningApplication+WindowInfo.swift */; };
 		D57925902A1AB1DA003B83EA /* NSRunningApplication+FloatingApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D579258F2A1AB1DA003B83EA /* NSRunningApplication+FloatingApp.swift */; };
 		D57925922A1ACA0B003B83EA /* AppKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57925912A1ACA0B003B83EA /* AppKind.swift */; };
@@ -311,6 +312,7 @@
 		D52E2C56293D31E00017CB7E /* FocusAwareTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusAwareTextField.swift; sourceTree = "<group>"; };
 		D56A7CFB28A4D5C0002F356A /* AXSwift+Browser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AXSwift+Browser.swift"; sourceTree = "<group>"; };
 		D57334252A84B40B00C8438F /* IconMap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconMap.swift; sourceTree = "<group>"; };
+		D57400002F69D8A600000001 /* CodexTerminalDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexTerminalDetector.swift; sourceTree = "<group>"; };
 		D579258B2A1AB0A4003B83EA /* NSRunningApplication+WindowInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRunningApplication+WindowInfo.swift"; sourceTree = "<group>"; };
 		D579258F2A1AB1DA003B83EA /* NSRunningApplication+FloatingApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSRunningApplication+FloatingApp.swift"; sourceTree = "<group>"; };
 		D57925912A1ACA0B003B83EA /* AppKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppKind.swift; sourceTree = "<group>"; };
@@ -455,6 +457,7 @@
 				D598C7E728B79E22004747D1 /* Log */,
 				4AC5738428411B33000BF10B /* AppKeyboardCache.swift */,
 				D57925912A1ACA0B003B83EA /* AppKind.swift */,
+				D57400002F69D8A600000001 /* CodexTerminalDetector.swift */,
 				4A0930882867E91100232089 /* AppsDiff.swift */,
 				4A2A1761280BA7FA00E13249 /* UserDefault.swift */,
 				4A2A1763280BA7FA00E13249 /* CancelBag.swift */,
@@ -936,6 +939,7 @@
 				4A881A98288CDDD500B76498 /* MainStorage.swift in Sources */,
 				4A09307D285F32B100232089 /* PreferencesWindowController+NSToolbar.swift in Sources */,
 				D57925922A1ACA0B003B83EA /* AppKind.swift in Sources */,
+				D57400012F69D8A600000001 /* CodexTerminalDetector.swift in Sources */,
 				4A4E035C2DB97534008E5C2F /* PromotionBadge.swift in Sources */,
 				4A09307B285F31E800232089 /* NSToolbarItem+Identifier.swift in Sources */,
 				4A2A1788280BA7FA00E13249 /* NSImage+Extension.swift in Sources */,

--- a/Input Source Pro/Models/ApplicationVM.swift
+++ b/Input Source Pro/Models/ApplicationVM.swift
@@ -46,6 +46,7 @@ extension ApplicationVM {
                 didActivateAppNotification.eraseToAnyPublisher(),
                 activeSpaceDidChangeNotification.eraseToAnyPublisher()
             ])
+            .prepend(())
             .compactMap { [weak self] _ -> NSRunningApplication? in
                 guard self?.preferencesVM.preferences.isEnhancedModeEnabled == true,
                       let elm: UIElement = try? systemWideElement.attribute(.focusedApplication),
@@ -61,8 +62,27 @@ extension ApplicationVM {
                 guard let preferencesVM = self?.preferencesVM
                 else { return Empty().eraseToAnyPublisher() }
 
-                guard NSApplication.isBrowser(app)
+                let shouldWatchCodexTerminal = app.bundleIdentifier == CodexTerminalDetector.bundleIdentifier
+                    && preferencesVM.preferences.isEnhancedModeEnabled
+                    && preferencesVM.codexTerminalInputSource != nil
+
+                guard NSApplication.isBrowser(app) || shouldWatchCodexTerminal
                 else { return Just(.from(app, preferencesVM: preferencesVM)).eraseToAnyPublisher() }
+
+                if shouldWatchCodexTerminal {
+                    // Chromium/Electron only exposes the web content accessibility tree (where the
+                    // xterm-helper-textarea lives) after `AXManualAccessibility` is set to true on
+                    // the app's AX element. Without this, `focusedUIElement` returns kAXNoValue and
+                    // `CodexTerminalDetector` can never see the terminal markers, so we'd fall back
+                    // to the app's default input source instead of `codexTerminalInputSource`.
+                    app.activateAccessibilities()
+
+                    return Timer
+                        .interval(seconds: 0.25)
+                        .prepend(Date())
+                        .map { _ in AppKind.from(app, preferencesVM: preferencesVM) }
+                        .eraseToAnyPublisher()
+                }
 
                 return Timer
                     .interval(seconds: 1)

--- a/Input Source Pro/Models/PreferencesVM+AppKeyboardCache.swift
+++ b/Input Source Pro/Models/PreferencesVM+AppKeyboardCache.swift
@@ -31,7 +31,7 @@ extension PreferencesVM {
     }
 
     func cacheKeyboardFor(_ appKind: AppKind, keyboard: InputSource) {
-        if appKind.isCodexTerminal {
+        if appKind.isFocusedOnCodexTerminal {
             appKeyboardCache.remove(appKind)
             return
         }
@@ -69,7 +69,7 @@ extension PreferencesVM {
     func getAppAutoSwitchKeyboard(
         _ appKind: AppKind
     ) -> AppAutoSwitchKeyboardStatus? {
-        if appKind.isCodexTerminal,
+        if appKind.isFocusedOnCodexTerminal,
            let defaultKeyboard = getAppDefaultKeyboard(appKind)
         {
             return .specified(defaultKeyboard)
@@ -99,7 +99,7 @@ extension PreferencesVM {
     }
 
     func getAppDefaultKeyboard(_ appKind: AppKind) -> InputSource? {
-        if appKind.isCodexTerminal,
+        if appKind.isFocusedOnCodexTerminal,
            let codexTerminalKeyboard = codexTerminalInputSource
         {
             return codexTerminalKeyboard

--- a/Input Source Pro/Models/PreferencesVM+AppKeyboardCache.swift
+++ b/Input Source Pro/Models/PreferencesVM+AppKeyboardCache.swift
@@ -31,6 +31,11 @@ extension PreferencesVM {
     }
 
     func cacheKeyboardFor(_ appKind: AppKind, keyboard: InputSource) {
+        if appKind.isCodexTerminal {
+            appKeyboardCache.remove(appKind)
+            return
+        }
+
         let defaultKeyboard = getAppDefaultKeyboard(appKind)
 
         if appNeedCacheKeyboard(appKind),
@@ -64,6 +69,12 @@ extension PreferencesVM {
     func getAppAutoSwitchKeyboard(
         _ appKind: AppKind
     ) -> AppAutoSwitchKeyboardStatus? {
+        if appKind.isCodexTerminal,
+           let defaultKeyboard = getAppDefaultKeyboard(appKind)
+        {
+            return .specified(defaultKeyboard)
+        }
+
         if let cachedKeyboard = getAppCachedKeyboard(appKind) {
             return .cached(cachedKeyboard)
         }
@@ -88,6 +99,12 @@ extension PreferencesVM {
     }
 
     func getAppDefaultKeyboard(_ appKind: AppKind) -> InputSource? {
+        if appKind.isCodexTerminal,
+           let codexTerminalKeyboard = codexTerminalInputSource
+        {
+            return codexTerminalKeyboard
+        }
+
         if appKind.getBrowserInfo()?.isFocusedOnAddressBar == true,
            let browserAddressKeyboard = browserAddressDefaultKeyboard
         {

--- a/Input Source Pro/Models/PreferencesVM.swift
+++ b/Input Source Pro/Models/PreferencesVM.swift
@@ -255,6 +255,7 @@ struct Preferences {
         static let cJKVFixStrategy = "cJKVFixStrategy"
 
         static let systemWideDefaultKeyboardId = "systemWideDefaultKeyboardId"
+        static let codexTerminalInputSourceId = "codexTerminalInputSourceId"
         static let isFunctionKeysEnabled = "isFunctionKeysEnabled"
 
         static let browserAddressDefaultKeyboardId = "browserAddressDefaultKeyboardId"
@@ -402,6 +403,9 @@ struct Preferences {
 
     @UserDefault(Preferences.Key.systemWideDefaultKeyboardId)
     var systemWideDefaultKeyboardId = ""
+
+    @UserDefault(Preferences.Key.codexTerminalInputSourceId)
+    var codexTerminalInputSourceId = ""
 
     // MARK: - Browser Rules
 
@@ -611,6 +615,10 @@ extension PreferencesVM {
 
     var browserAddressDefaultKeyboard: InputSource? {
         return InputSource.resolvePersistedIdentifier(preferences.browserAddressDefaultKeyboardId)
+    }
+
+    var codexTerminalInputSource: InputSource? {
+        return InputSource.resolvePersistedIdentifier(preferences.codexTerminalInputSourceId)
     }
 }
 

--- a/Input Source Pro/Persistence/SettingsBackup.swift
+++ b/Input Source Pro/Persistence/SettingsBackup.swift
@@ -115,6 +115,7 @@ struct SettingsBackupPreferences: Codable {
     var singleModifierInputSourceMapping: [String: ModifierCombo]?
     var singleModifierGroupMapping: [String: ModifierCombo]?
     var systemWideDefaultKeyboardId: String?
+    var codexTerminalInputSourceId: String?
     var browserAddressDefaultKeyboardId: String?
     var isEnableURLSwitchForSafari: Bool?
     var isEnableURLSwitchForSafariTechnologyPreview: Bool?
@@ -169,6 +170,7 @@ struct SettingsBackupPreferences: Codable {
         singleModifierInputSourceMapping = preferences.singleModifierInputSourceMapping
         singleModifierGroupMapping = preferences.singleModifierGroupMapping
         systemWideDefaultKeyboardId = preferences.systemWideDefaultKeyboardId
+        codexTerminalInputSourceId = preferences.codexTerminalInputSourceId
         browserAddressDefaultKeyboardId = preferences.browserAddressDefaultKeyboardId
         isEnableURLSwitchForSafari = preferences.isEnableURLSwitchForSafari
         isEnableURLSwitchForSafariTechnologyPreview = preferences.isEnableURLSwitchForSafariTechnologyPreview
@@ -236,6 +238,7 @@ struct SettingsBackupPreferences: Codable {
         }
         if let singleModifierGroupMapping { preferences.singleModifierGroupMapping = singleModifierGroupMapping }
         if let systemWideDefaultKeyboardId { preferences.systemWideDefaultKeyboardId = systemWideDefaultKeyboardId }
+        if let codexTerminalInputSourceId { preferences.codexTerminalInputSourceId = codexTerminalInputSourceId }
         if let browserAddressDefaultKeyboardId {
             preferences.browserAddressDefaultKeyboardId = browserAddressDefaultKeyboardId
         }

--- a/Input Source Pro/Resources/en.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/en.lproj/Localizable.strings
@@ -115,6 +115,7 @@
 "%@ App(s) Selected" = "%@ App(s) Selected";
 "System-Wide" = "System-Wide";
 "Default Keyboard" = "Default Input Source";
+"Codex Terminal Input Source" = "Codex Terminal Input Source";
 "Default Function Keys" = "Default Function Keys";
 "Function Keys" = "Function Keys";
 "Keyboard Restore Strategy" = "Input Source Restore Strategy";

--- a/Input Source Pro/Resources/ja.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/ja.lproj/Localizable.strings
@@ -115,6 +115,7 @@
 "%@ App(s) Selected" = "%@個のアプリが選択されました";
 "System-Wide" = "システム全体";
 "Default Keyboard" = "デフォルトキーボード";
+"Codex Terminal Input Source" = "Codex ターミナル入力ソース";
 "Default Function Keys" = "デフォルトのファンクションキー";
 "Function Keys" = "ファンクションキー";
 "Keyboard Restore Strategy" = "キーボード復元戦略";

--- a/Input Source Pro/Resources/ko.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/ko.lproj/Localizable.strings
@@ -115,6 +115,7 @@
 "%@ App(s) Selected" = "%@개 앱 선택됨";
 "System-Wide" = "시스템 전체";
 "Default Keyboard" = "기본 입력 소스";
+"Codex Terminal Input Source" = "Codex 터미널 입력 소스";
 "Default Function Keys" = "기본 기능 키";
 "Function Keys" = "기능 키";
 "Keyboard Restore Strategy" = "입력 소스 복원 전략";

--- a/Input Source Pro/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/zh-Hans.lproj/Localizable.strings
@@ -117,6 +117,7 @@
 "%@ App(s) Selected" = "已选中 %@ 个应用";
 "System-Wide" = "全局";
 "Default Keyboard" = "默认输入法";
+"Codex Terminal Input Source" = "Codex 终端输入法";
 "Default Function Keys" = "默认功能键";
 "Function Keys" = "功能键";
 "Keyboard Restore Strategy" = "输入法恢复策略";

--- a/Input Source Pro/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/zh-Hant.lproj/Localizable.strings
@@ -117,6 +117,7 @@
 "%@ App(s) Selected" = "已選取 %@ 個應用程式";
 "System-Wide" = "全域";
 "Default Keyboard" = "預設輸入法";
+"Codex Terminal Input Source" = "Codex 終端輸入法";
 "Default Function Keys" = "預設功能鍵";
 "Function Keys" = "功能鍵";
 "Keyboard Restore Strategy" = "輸入法復原模式";

--- a/Input Source Pro/UI/Components/RulesApplicationDetail.swift
+++ b/Input Source Pro/UI/Components/RulesApplicationDetail.swift
@@ -12,7 +12,6 @@ struct ApplicationDetail: View {
     @State var hideIndicator = NSToggleViewState.off
     @State var forceEnglishPunctuation = NSToggleViewState.off
     @State var functionKeyModeItem: PickerItem?
-    @State var codexTerminalKeyboard: PickerItem?
 
     var mixed: Bool {
         Set(selectedApp.map { $0.forcedKeyboard?.persistentIdentifier }).count > 1
@@ -87,7 +86,7 @@ struct ApplicationDetail: View {
                     PopUpButtonPicker<PickerItem?>(
                         items: keyboardItems,
                         isItemEnabled: { $0?.id != "mixed" },
-                        isItemSelected: { $0 == codexTerminalKeyboard },
+                        isItemSelected: { $0 == selectedCodexTerminalKeyboard },
                         getTitle: { $0?.title ?? "" },
                         getToolTip: { $0?.toolTip },
                         onSelect: { handleCodexTerminalKeyboardSelect($0, items: keyboardItems) }
@@ -221,7 +220,6 @@ struct ApplicationDetail: View {
             updateHideIndicatorState()
             updateForceEnglishPunctuationState()
             updateFunctionKeyModeItem()
-            updateCodexTerminalKeyboard()
         }
     }
 
@@ -289,19 +287,6 @@ struct ApplicationDetail: View {
         }
 
         functionKeyModeItem = functionKeyItem(for: mode)
-    }
-
-    func updateCodexTerminalKeyboard() {
-        guard shouldShowCodexTerminalKeyboard else {
-            codexTerminalKeyboard = PickerItem.empty
-            return
-        }
-
-        if let inputSource = preferencesVM.codexTerminalInputSource {
-            codexTerminalKeyboard = pickerItem(for: inputSource)
-        } else {
-            codexTerminalKeyboard = PickerItem.empty
-        }
     }
 
     func handleSelect(_ index: Int, items: [PickerItem]) {
@@ -389,10 +374,10 @@ struct ApplicationDetail: View {
     }
 
     func handleCodexTerminalKeyboardSelect(_ index: Int, items: [PickerItem]) {
-        codexTerminalKeyboard = items[index]
+        let selection = items[index]
 
         preferencesVM.update {
-            $0.codexTerminalInputSourceId = codexTerminalKeyboard?.id ?? ""
+            $0.codexTerminalInputSourceId = selection.id
         }
     }
 
@@ -406,6 +391,13 @@ struct ApplicationDetail: View {
             title: inputSource.name,
             toolTip: inputSource.persistentIdentifier
         )
+    }
+
+    var selectedCodexTerminalKeyboard: PickerItem {
+        guard let inputSource = preferencesVM.codexTerminalInputSource
+        else { return .empty }
+
+        return pickerItem(for: inputSource)
     }
 
     func restoreStrategyName(strategy: KeyboardRestoreStrategy) -> String {

--- a/Input Source Pro/UI/Components/RulesApplicationDetail.swift
+++ b/Input Source Pro/UI/Components/RulesApplicationDetail.swift
@@ -1,18 +1,5 @@
 import SwiftUI
 
-// 新增 ToggleLabel 组件
-
-struct ToggleLabel: View {
-    let systemImageName: String
-    let text: String
-    var body: some View {
-        HStack(spacing: 6) {
-            RuleSettingIcon(systemName: systemImageName)
-            Text(text)
-        }
-    }
-}
-
 struct ApplicationDetail: View {
     @Binding var selectedApp: Set<AppRule>
 
@@ -25,6 +12,7 @@ struct ApplicationDetail: View {
     @State var hideIndicator = NSToggleViewState.off
     @State var forceEnglishPunctuation = NSToggleViewState.off
     @State var functionKeyModeItem: PickerItem?
+    @State var codexTerminalKeyboard: PickerItem?
 
     var mixed: Bool {
         Set(selectedApp.map { $0.forcedKeyboard?.persistentIdentifier }).count > 1
@@ -37,13 +25,17 @@ struct ApplicationDetail: View {
     var items: [PickerItem] {
         [mixed ? PickerItem.mixed : nil, PickerItem.empty].compactMap { $0 }
             + InputSource.sources.map {
-                PickerItem(id: $0.persistentIdentifier, title: $0.name, toolTip: $0.persistentIdentifier)
+                pickerItem(for: $0)
             }
     }
 
     var functionKeyItems: [PickerItem] {
         [isFunctionKeyModeMixed ? PickerItem.mixed : nil, functionKeyDefaultItem].compactMap { $0 }
             + functionKeyOptionItems
+    }
+
+    var shouldShowCodexTerminalKeyboard: Bool {
+        selectedApp.count == 1 && selectedApp.first?.bundleId == CodexTerminalDetector.bundleIdentifier
     }
 
     var functionKeyDefaultItem: PickerItem {
@@ -58,6 +50,8 @@ struct ApplicationDetail: View {
     }
 
     var body: some View {
+        let keyboardItems = items
+
         VStack(alignment: .leading) {
             Text(String(format: "%@ App(s) Selected".i18n(), "\(selectedApp.count)"))
                 .font(.subheadline.monospacedDigit())
@@ -69,17 +63,41 @@ struct ApplicationDetail: View {
                     .fontWeight(.medium)
 
                 PopUpButtonPicker<PickerItem?>(
-                    items: items,
+                    items: keyboardItems,
                     isItemEnabled: { $0?.id != "mixed" },
                     isItemSelected: { $0 == forceKeyboard },
                     getTitle: { $0?.title ?? "" },
                     getToolTip: { $0?.toolTip },
-                    onSelect: handleSelect
+                    onSelect: { handleSelect($0, items: keyboardItems) }
                 )
             }
 
             Divider()
                 .padding(.vertical, 4)
+
+            if shouldShowCodexTerminalKeyboard {
+                VStack(alignment: .leading) {
+                    HStack {
+                        Text("Codex Terminal Input Source".i18n())
+                            .fontWeight(.medium)
+                        Spacer()
+                        EnhancedModeRequiredBadge()
+                    }
+
+                    PopUpButtonPicker<PickerItem?>(
+                        items: keyboardItems,
+                        isItemEnabled: { $0?.id != "mixed" },
+                        isItemSelected: { $0 == codexTerminalKeyboard },
+                        getTitle: { $0?.title ?? "" },
+                        getToolTip: { $0?.toolTip },
+                        onSelect: { handleCodexTerminalKeyboardSelect($0, items: keyboardItems) }
+                    )
+                    .disabled(!preferencesVM.preferences.isEnhancedModeEnabled)
+                }
+
+                Divider()
+                    .padding(.vertical, 4)
+            }
 
             VStack(alignment: .leading) {
                 Text("Function Keys".i18n())
@@ -203,6 +221,7 @@ struct ApplicationDetail: View {
             updateHideIndicatorState()
             updateForceEnglishPunctuationState()
             updateFunctionKeyModeItem()
+            updateCodexTerminalKeyboard()
         }
     }
 
@@ -210,11 +229,7 @@ struct ApplicationDetail: View {
         if mixed {
             forceKeyboard = PickerItem.mixed
         } else if let keyboard = selectedApp.first?.forcedKeyboard {
-            forceKeyboard = PickerItem(
-                id: keyboard.persistentIdentifier,
-                title: keyboard.name,
-                toolTip: keyboard.persistentIdentifier
-            )
+            forceKeyboard = pickerItem(for: keyboard)
         } else {
             forceKeyboard = PickerItem.empty
         }
@@ -276,7 +291,20 @@ struct ApplicationDetail: View {
         functionKeyModeItem = functionKeyItem(for: mode)
     }
 
-    func handleSelect(_ index: Int) {
+    func updateCodexTerminalKeyboard() {
+        guard shouldShowCodexTerminalKeyboard else {
+            codexTerminalKeyboard = PickerItem.empty
+            return
+        }
+
+        if let inputSource = preferencesVM.codexTerminalInputSource {
+            codexTerminalKeyboard = pickerItem(for: inputSource)
+        } else {
+            codexTerminalKeyboard = PickerItem.empty
+        }
+    }
+
+    func handleSelect(_ index: Int, items: [PickerItem]) {
         forceKeyboard = items[index]
 
         for app in selectedApp {
@@ -360,8 +388,24 @@ struct ApplicationDetail: View {
         selectedApp.forEach { preferencesVM.setFunctionKeyMode($0, mode) }
     }
 
+    func handleCodexTerminalKeyboardSelect(_ index: Int, items: [PickerItem]) {
+        codexTerminalKeyboard = items[index]
+
+        preferencesVM.update {
+            $0.codexTerminalInputSourceId = codexTerminalKeyboard?.id ?? ""
+        }
+    }
+
     func functionKeyItem(for mode: FKeyMode) -> PickerItem {
         functionKeyOptionItems.first(where: { $0.id == mode.rawValue }) ?? functionKeyDefaultItem
+    }
+
+    func pickerItem(for inputSource: InputSource) -> PickerItem {
+        PickerItem(
+            id: inputSource.persistentIdentifier,
+            title: inputSource.name,
+            toolTip: inputSource.persistentIdentifier
+        )
     }
 
     func restoreStrategyName(strategy: KeyboardRestoreStrategy) -> String {

--- a/Input Source Pro/Utilities/AppKind.swift
+++ b/Input Source Pro/Utilities/AppKind.swift
@@ -17,7 +17,7 @@ enum AppKind {
     typealias NormalInfo = (
         focusedElement: UIElement?,
         isFocusOnInputContainer: Bool,
-        isCodexTerminal: Bool
+        isFocusedOnCodexTerminal: Bool
     )
 
     case normal(app: NSRunningApplication, info: NormalInfo)
@@ -27,7 +27,7 @@ enum AppKind {
         switch self {
         case let .normal(app, info):
             guard let bundleId = app.bundleId() else { return nil }
-            return info.isCodexTerminal ? "\(bundleId)_codex_terminal" : bundleId
+            return info.isFocusedOnCodexTerminal ? "\(bundleId)_codex_terminal" : bundleId
         case let .browser(app, info):
             if !info.isFocusedOnAddressBar,
                info.url != .newtab,
@@ -83,7 +83,7 @@ enum AppKind {
 
         let isSameAddress = getBrowserInfo()?.url == otherKind.getBrowserInfo()?.url
         let isSameAddressBar = getBrowserInfo()?.isFocusedOnAddressBar == otherKind.getBrowserInfo()?.isFocusedOnAddressBar
-        let isSameCodexTerminalState = isCodexTerminal == otherKind.isCodexTerminal
+        let isSameCodexTerminalState = isFocusedOnCodexTerminal == otherKind.isFocusedOnCodexTerminal
 
         return detectAddressBar
             ? (isSameAddressBar && isSameAddress && isSameCodexTerminalState)
@@ -92,10 +92,10 @@ enum AppKind {
 }
 
 extension AppKind {
-    var isCodexTerminal: Bool {
+    var isFocusedOnCodexTerminal: Bool {
         switch self {
         case let .normal(_, info):
-            return info.isCodexTerminal
+            return info.isFocusedOnCodexTerminal
         case .browser:
             return false
         }
@@ -117,7 +117,7 @@ extension AppKind {
         let application = app.getApplication(preferencesVM: preferencesVM)
         let focusedElement = app.focuedUIElement(application: application)
         let isFocusOnInputContainer = UIElement.isInputContainer(focusedElement)
-        let isCodexTerminal = app.bundleIdentifier == CodexTerminalDetector.bundleIdentifier
+        let isFocusedOnCodexTerminal = app.bundleIdentifier == CodexTerminalDetector.bundleIdentifier
             && preferencesVM.codexTerminalInputSource != nil
             && CodexTerminalDetector.isTerminalFocused(
                 app: app,
@@ -144,7 +144,7 @@ extension AppKind {
                 info: (
                     focusedElement,
                     isFocusOnInputContainer,
-                    isCodexTerminal
+                    isFocusedOnCodexTerminal
                 )
             )
         }

--- a/Input Source Pro/Utilities/AppKind.swift
+++ b/Input Source Pro/Utilities/AppKind.swift
@@ -16,7 +16,8 @@ enum AppKind {
 
     typealias NormalInfo = (
         focusedElement: UIElement?,
-        isFocusOnInputContainer: Bool
+        isFocusOnInputContainer: Bool,
+        isCodexTerminal: Bool
     )
 
     case normal(app: NSRunningApplication, info: NormalInfo)
@@ -24,8 +25,9 @@ enum AppKind {
 
     func getId() -> String? {
         switch self {
-        case let .normal(app, _):
-            return app.bundleId()
+        case let .normal(app, info):
+            guard let bundleId = app.bundleId() else { return nil }
+            return info.isCodexTerminal ? "\(bundleId)_codex_terminal" : bundleId
         case let .browser(app, info):
             if !info.isFocusedOnAddressBar,
                info.url != .newtab,
@@ -81,8 +83,22 @@ enum AppKind {
 
         let isSameAddress = getBrowserInfo()?.url == otherKind.getBrowserInfo()?.url
         let isSameAddressBar = getBrowserInfo()?.isFocusedOnAddressBar == otherKind.getBrowserInfo()?.isFocusedOnAddressBar
+        let isSameCodexTerminalState = isCodexTerminal == otherKind.isCodexTerminal
 
-        return detectAddressBar ? (isSameAddressBar && isSameAddress) : isSameAddress
+        return detectAddressBar
+            ? (isSameAddressBar && isSameAddress && isSameCodexTerminalState)
+            : (isSameAddress && isSameCodexTerminalState)
+    }
+}
+
+extension AppKind {
+    var isCodexTerminal: Bool {
+        switch self {
+        case let .normal(_, info):
+            return info.isCodexTerminal
+        case .browser:
+            return false
+        }
     }
 }
 
@@ -101,6 +117,12 @@ extension AppKind {
         let application = app.getApplication(preferencesVM: preferencesVM)
         let focusedElement = app.focuedUIElement(application: application)
         let isFocusOnInputContainer = UIElement.isInputContainer(focusedElement)
+        let isCodexTerminal = app.bundleIdentifier == CodexTerminalDetector.bundleIdentifier
+            && preferencesVM.codexTerminalInputSource != nil
+            && CodexTerminalDetector.isTerminalFocused(
+                app: app,
+                focusedElement: focusedElement
+            )
 
         if let url = preferencesVM.getBrowserURL(app.bundleIdentifier, application: application)?.removeFragment() {
             let rule = preferencesVM.getBrowserRule(url: url)
@@ -121,7 +143,8 @@ extension AppKind {
                 app: app,
                 info: (
                     focusedElement,
-                    isFocusOnInputContainer
+                    isFocusOnInputContainer,
+                    isCodexTerminal
                 )
             )
         }

--- a/Input Source Pro/Utilities/AppKit/NSRunningApplication.swift
+++ b/Input Source Pro/Utilities/AppKit/NSRunningApplication.swift
@@ -118,18 +118,22 @@ extension NSRunningApplication {
     }
 
     func activateAccessibility(attribute: String) {
-        if let application = Application(self),
-           let isSettable = try? application.attributeIsSettable(attribute),
-           isSettable
-        {
-            if let rawValue: AnyObject = try? application.attribute(attribute),
-               CFBooleanGetTypeID() == CFGetTypeID(rawValue),
-               let enabled = rawValue as? Bool, enabled
-            {
-                return
-            }
+        guard let application = Application(self) else { return }
 
-            try? application.setAttribute(attribute, value: true)
+        // Skip if already enabled to avoid redundant writes.
+        if let rawValue: AnyObject = try? application.attribute(attribute),
+           CFBooleanGetTypeID() == CFGetTypeID(rawValue),
+           let enabled = rawValue as? Bool, enabled
+        {
+            return
         }
+
+        // Always attempt the set. Chromium/Electron apps (e.g. Codex) report
+        // `attributeIsSettable == false` for `AXManualAccessibility` until the
+        // attribute has been written at least once, so the previous settability
+        // gate made this a permanent no-op and prevented the web AX tree from
+        // ever being exposed. The attribute is documented as a write-only opt-in
+        // for AT clients, so unconditionally writing matches the platform contract.
+        try? application.setAttribute(attribute, value: true)
     }
 }

--- a/Input Source Pro/Utilities/CodexTerminalDetector.swift
+++ b/Input Source Pro/Utilities/CodexTerminalDetector.swift
@@ -1,0 +1,59 @@
+import AppKit
+import AXSwift
+
+enum CodexTerminalDetector {
+    static let bundleIdentifier = "com.openai.codex"
+
+    private static let maxAncestorDepth = 16
+    private static let terminalKeywords = ["terminal", "xterm", "pty", "console", "shell"]
+
+    static func isTerminalFocused(
+        app: NSRunningApplication,
+        focusedElement: UIElement?
+    ) -> Bool {
+        guard app.bundleIdentifier == bundleIdentifier,
+              let focusedElement
+        else { return false }
+
+        return hasTerminalAccessibilityMarker(focusedElement)
+    }
+
+    private static func hasTerminalAccessibilityMarker(_ focusedElement: UIElement) -> Bool {
+        var element: UIElement? = focusedElement
+
+        for _ in 0 ..< maxAncestorDepth {
+            guard let current = element else { return false }
+
+            if elementLooksLikeTerminal(current) {
+                return true
+            }
+
+            element = try? current.attribute(.parent)
+        }
+
+        return false
+    }
+
+    private static func elementLooksLikeTerminal(_ element: UIElement) -> Bool {
+        let textValues = [
+            element.safeString(attribute: .identifier),
+            element.safeString(attribute: "AXDOMIdentifier"),
+            element.safeString(attribute: .title),
+            element.safeString(attribute: .description),
+            element.safeString(attribute: "AXHelp"),
+            element.safeString(attribute: "AXRoleDescription"),
+        ]
+        .compactMap { $0 }
+
+        if textValues.contains(where: containsTerminalKeyword) {
+            return true
+        }
+
+        return element.domClassList().contains(where: containsTerminalKeyword)
+    }
+
+    private static func containsTerminalKeyword(_ value: String) -> Bool {
+        let value = value.lowercased()
+        return terminalKeywords.contains { value.contains($0) }
+    }
+}

--- a/Input Source Pro/Utilities/CodexTerminalDetector.swift
+++ b/Input Source Pro/Utilities/CodexTerminalDetector.swift
@@ -5,7 +5,16 @@ enum CodexTerminalDetector {
     static let bundleIdentifier = "com.openai.codex"
 
     private static let maxAncestorDepth = 16
-    private static let terminalKeywords = ["terminal", "xterm", "pty", "console", "shell"]
+
+    // xterm.js prefixes every class on the helper textarea, its container, and
+    // its render layers with `xterm` (e.g. `xterm-helper-textarea`,
+    // `xterm-screen`, `xterm-viewport`, `xterm-rows`, `xterm-cursor-layer`).
+    // Matching this prefix on AXDOMClassList is both specific to xterm.js and
+    // resilient to version changes. We deliberately avoid broad keywords like
+    // `terminal` / `console` / `shell`, because Codex labels other panes with
+    // those words, which caused the terminal input source to be applied to the
+    // chat composer as well.
+    private static let xtermClassPrefix = "xterm"
 
     static func isTerminalFocused(
         app: NSRunningApplication,
@@ -15,16 +24,16 @@ enum CodexTerminalDetector {
               let focusedElement
         else { return false }
 
-        return hasTerminalAccessibilityMarker(focusedElement)
+        return hasXtermAncestor(focusedElement)
     }
 
-    private static func hasTerminalAccessibilityMarker(_ focusedElement: UIElement) -> Bool {
+    private static func hasXtermAncestor(_ focusedElement: UIElement) -> Bool {
         var element: UIElement? = focusedElement
 
         for _ in 0 ..< maxAncestorDepth {
             guard let current = element else { return false }
 
-            if elementLooksLikeTerminal(current) {
+            if elementHasXtermClass(current) {
                 return true
             }
 
@@ -34,26 +43,7 @@ enum CodexTerminalDetector {
         return false
     }
 
-    private static func elementLooksLikeTerminal(_ element: UIElement) -> Bool {
-        let textValues = [
-            element.safeString(attribute: .identifier),
-            element.safeString(attribute: "AXDOMIdentifier"),
-            element.safeString(attribute: .title),
-            element.safeString(attribute: .description),
-            element.safeString(attribute: "AXHelp"),
-            element.safeString(attribute: "AXRoleDescription"),
-        ]
-        .compactMap { $0 }
-
-        if textValues.contains(where: containsTerminalKeyword) {
-            return true
-        }
-
-        return element.domClassList().contains(where: containsTerminalKeyword)
-    }
-
-    private static func containsTerminalKeyword(_ value: String) -> Bool {
-        let value = value.lowercased()
-        return terminalKeywords.contains { value.contains($0) }
+    private static func elementHasXtermClass(_ element: UIElement) -> Bool {
+        return element.domClassList().contains { $0.hasPrefix(xtermClassPrefix) }
     }
 }


### PR DESCRIPTION
## What changed
- Added a dedicated Codex terminal input source setting.
- Narrowed the Codex terminal detection so it only applies when focus is actually inside the terminal area.
- Simplified the rule editor so it reads the saved setting directly instead of keeping a duplicate local selection state.

## Why
Codex uses a Chromium/Electron terminal surface. The app now distinguishes that terminal focus from the rest of the Codex window, so the input source switch only applies where it should.

## Validation
- `git diff --check`
- `xcodebuild -scheme "Input Source Pro" -configuration Debug build`
