### PR TITLE
feat(indicator): add toggle for text input source icons.

### DIFF
--- a/Input Source Pro/Controllers/IndicatorWindowController+Indicator.swift
+++ b/Input Source Pro/Controllers/IndicatorWindowController+Indicator.swift
@@ -19,6 +19,7 @@ extension IndicatorWindowController {
                 size: preferences.indicatorSize ?? .medium,
                 bgColor: preferencesVM.defaultIndicatorBgNSColor,
                 textColor: preferencesVM.defaultIndicatorTextNSColor,
+                prefersTextInputSourceIcons: preferences.prefersTextInputSourceIcons,
                 badge: .init(glyph: mode.badgeGlyph, title: mode.displayName)
             ))
 
@@ -34,7 +35,8 @@ extension IndicatorWindowController {
             kind: preferences.indicatorKind,
             size: preferences.indicatorSize ?? .medium,
             bgColor: preferencesVM.getBgNSColor(inputSource),
-            textColor: preferencesVM.getTextNSColor(inputSource)
+            textColor: preferencesVM.getTextNSColor(inputSource),
+            prefersTextInputSourceIcons: preferences.prefersTextInputSourceIcons
         ))
 
         if isActive {

--- a/Input Source Pro/Models/PreferencesVM.swift
+++ b/Input Source Pro/Models/PreferencesVM.swift
@@ -319,6 +319,7 @@ struct Preferences {
         static let isAutoAppearanceMode = "isAutoAppearanceMode"
         static let appearanceMode = "appearanceMode"
         static let isShowInputSourcesLabel = "isShowInputSourcesLabel"
+        static let prefersTextInputSourceIcons = "prefersTextInputSourceIcons"
         static let indicatorBackground = "indicatorBackground"
         static let indicatorForgeground = "indicatorForgeground"
 
@@ -504,6 +505,9 @@ struct Preferences {
 
     @CodableUserDefault(Preferences.Key.indicatorSize)
     var indicatorSize = IndicatorSize.medium
+
+    @UserDefault(Preferences.Key.prefersTextInputSourceIcons)
+    var prefersTextInputSourceIcons = true
 
     @UserDefault(Preferences.Key.isAutoAppearanceMode)
     var isAutoAppearanceMode = true

--- a/Input Source Pro/Resources/en.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/en.lproj/Localizable.strings
@@ -96,6 +96,7 @@
 
 "Appearance" = "Appearance";
 "Indicator Info" = "Indicator Info";
+"Use Text Input Source Icons" = "Use Text Input Source Icons";
 "Icon and Title" = "Icon and Title";
 "Icon" = "Icon";
 "Title" = "Title";

--- a/Input Source Pro/Resources/ja.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/ja.lproj/Localizable.strings
@@ -96,6 +96,7 @@
 
 "Appearance" = "外観";
 "Indicator Info" = "インジケーター情報";
+"Use Text Input Source Icons" = "文字入力ソースアイコンを使用";
 "Icon and Title" = "アイコンとタイトル";
 "Icon" = "アイコン";
 "Title" = "タイトル";

--- a/Input Source Pro/Resources/ko.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/ko.lproj/Localizable.strings
@@ -96,6 +96,7 @@
 
 "Appearance" = "외관";
 "Indicator Info" = "표시기 정보";
+"Use Text Input Source Icons" = "텍스트 입력 소스 아이콘 사용";
 "Icon and Title" = "아이콘 및 제목";
 "Icon" = "아이콘";
 "Title" = "제목";

--- a/Input Source Pro/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/zh-Hans.lproj/Localizable.strings
@@ -98,6 +98,7 @@
 
 "Appearance" = "外观";
 "Indicator Info" = "指示器信息";
+"Use Text Input Source Icons" = "使用文字输入法图标";
 "Icon and Title" = "图标和标题";
 "Icon" = "图标";
 "Title" = "标题";

--- a/Input Source Pro/Resources/zh-Hant.lproj/Localizable.strings
+++ b/Input Source Pro/Resources/zh-Hant.lproj/Localizable.strings
@@ -98,6 +98,7 @@
 
 "Appearance" = "外觀";
 "Indicator Info" = "指示器資訊";
+"Use Text Input Source Icons" = "使用文字輸入法圖示";
 "Icon and Title" = "圖示和標題";
 "Icon" = "圖示";
 "Title" = "標題";

--- a/Input Source Pro/UI/Components/CustomizedIndicatorView.swift
+++ b/Input Source Pro/UI/Components/CustomizedIndicatorView.swift
@@ -15,8 +15,9 @@ struct CustomizedIndicatorView: View {
                 inputSource: inputSource,
                 kind: preferencesVM.preferences.indicatorKind,
                 size: preferencesVM.preferences.indicatorSize ?? .medium,
-                bgColor: NSColor(preferencesVM.getBgColor(inputSource)),
-                textColor: NSColor(preferencesVM.getTextColor(inputSource))
+                bgColor: nil,
+                textColor: NSColor(preferencesVM.getTextColor(inputSource)),
+                prefersTextInputSourceIcons: preferencesVM.preferences.prefersTextInputSourceIcons
             ))
         }
     }

--- a/Input Source Pro/UI/Components/IndicatorView.swift
+++ b/Input Source Pro/UI/Components/IndicatorView.swift
@@ -15,7 +15,8 @@ struct IndicatorView: NSViewControllerRepresentable {
             kind: preferencesVM.preferences.indicatorKind,
             size: preferencesVM.preferences.indicatorSize ?? .medium,
             bgColor: NSColor(preferencesVM.preferences.indicatorBackgroundColor),
-            textColor: NSColor(preferencesVM.preferences.indicatorForgegroundColor)
+            textColor: NSColor(preferencesVM.preferences.indicatorForgegroundColor),
+            prefersTextInputSourceIcons: preferencesVM.preferences.prefersTextInputSourceIcons
         ))
 
         indicatorViewController.refresh()

--- a/Input Source Pro/UI/Components/KeyboardCustomization.swift
+++ b/Input Source Pro/UI/Components/KeyboardCustomization.swift
@@ -30,7 +30,8 @@ struct KeyboardCustomization: View {
                         kind: .alwaysOn,
                         size: preferencesVM.preferences.indicatorSize ?? .medium,
                         bgColor: NSColor(bgColor),
-                        textColor: NSColor(textColor)
+                        textColor: NSColor(textColor),
+                        prefersTextInputSourceIcons: preferencesVM.preferences.prefersTextInputSourceIcons
                     ))
 
                     DumpIndicatorView(config: IndicatorViewConfig(
@@ -38,7 +39,8 @@ struct KeyboardCustomization: View {
                         kind: preferencesVM.preferences.indicatorKind,
                         size: preferencesVM.preferences.indicatorSize ?? .medium,
                         bgColor: NSColor(bgColor),
-                        textColor: NSColor(textColor)
+                        textColor: NSColor(textColor),
+                        prefersTextInputSourceIcons: preferencesVM.preferences.prefersTextInputSourceIcons
                     ))
 
                     Text("Always-On Indicator Style")

--- a/Input Source Pro/UI/Screens/AppearanceSettingsView.swift
+++ b/Input Source Pro/UI/Screens/AppearanceSettingsView.swift
@@ -55,6 +55,18 @@ struct AppearanceSettingsView: View {
                         .labelsHidden()
                         .pickerStyle(.segmented)
                         .padding()
+
+                        HStack {
+                            Toggle("", isOn: $preferencesVM.preferences.prefersTextInputSourceIcons)
+                                .toggleStyle(.switch)
+                                .labelsHidden()
+
+                            Text("Use Text Input Source Icons".i18n())
+
+                            Spacer()
+                        }
+                        .padding()
+                        .border(width: 1, edges: [.top], color: NSColor.border2.color)
                     }
                 }
 

--- a/Input Source Pro/UI/Screens/KeyboardsSettingsView.swift
+++ b/Input Source Pro/UI/Screens/KeyboardsSettingsView.swift
@@ -137,8 +137,9 @@ struct KeyboardsSettingsView: View {
                         inputSource: indicatorVM.state.inputSource,
                         kind: preferencesVM.preferences.indicatorKind,
                         size: preferencesVM.preferences.indicatorSize ?? .medium,
-                        bgColor: preferencesVM.defaultIndicatorBgNSColor,
+                        bgColor: nil,
                         textColor: preferencesVM.defaultIndicatorTextNSColor,
+                        prefersTextInputSourceIcons: preferencesVM.preferences.prefersTextInputSourceIcons,
                         badge: .init(
                             glyph: currentFunctionKeyMode.badgeGlyph,
                             title: currentFunctionKeyMode.displayName

--- a/Input Source Pro/Utilities/Indicator/IndicatorViewConfig.swift
+++ b/Input Source Pro/Utilities/Indicator/IndicatorViewConfig.swift
@@ -21,6 +21,7 @@ struct IndicatorViewConfig {
     let size: IndicatorSize
     let bgColor: NSColor?
     let textColor: NSColor?
+    let prefersTextInputSourceIcons: Bool
 
     /// When set, the indicator renders this glyph (SF Symbol or text) + title
     /// instead of the input source. Lets the same pill machinery show
@@ -217,7 +218,9 @@ struct IndicatorViewConfig {
     }
 
     private func getImageView(_ inputSource: InputSource) -> NSView? {
-//    if let textImage = getTextImageView(inputSource) { return textImage }
+        if prefersTextInputSourceIcons, let textImage = getTextImageView(inputSource) {
+            return textImage
+        }
 
         guard let image = inputSource.icon
         else { return nil }
@@ -265,26 +268,23 @@ struct IndicatorViewConfig {
         else { return nil }
 
         let labelView = NSTextField(labelWithString: labelName)
-        let view = NSView()
+        labelView.textColor = textColor
+        labelView.alignment = .center
 
-        view.addSubview(labelView)
-        view.wantsLayer = true
-        view.layer?.backgroundColor = textColor?.cgColor
-        view.layer?.cornerRadius = 2
-
-        labelView.snp.makeConstraints {
-            $0.center.equalTo(view)
+        switch size {
+        case .small:
+            labelView.font = .systemFont(ofSize: labelName.count > 1 ? 7 : 10, weight: .regular)
+        case .medium:
+            labelView.font = .systemFont(ofSize: labelName.count > 1 ? 10 : 13, weight: .regular)
+        case .large:
+            labelView.font = .systemFont(ofSize: labelName.count > 1 ? 15 : 20, weight: .regular)
         }
 
-        view.snp.makeConstraints {
-//      $0.width.equalTo(22)
-            $0.width.height.equalTo(16)
+        labelView.snp.makeConstraints { make in
+            make.width.equalTo(max(leadingIconWidth, labelView.intrinsicContentSize.width))
         }
 
-        labelView.textColor = bgColor
-        labelView.font = .systemFont(ofSize: labelName.count > 1 ? 10 : 11, weight: .regular)
-
-        return view
+        return labelView
     }
 
     private func getContainerView() -> NSView {


### PR DESCRIPTION
## Motivation

Input source icons are displayed with an extra inner frame by default. The text color inside the icon is tied to that frame's background color, so the existing color scheme settings cannot remove or restyle the frame independently.

`Old style`

<img width="780" height="648" alt="SCR-20260701-nrye" src="https://github.com/user-attachments/assets/12fd267d-f2af-4a69-995a-5b7e45b25794" />

The new option lets users switch to text-based input source icons while keeping the original icon style available.

`New style`

<img width="780" height="648" alt="SCR-20260701-nsci" src="https://github.com/user-attachments/assets/614a6559-8c54-457e-b694-337e3c1dd3d2" />

<img width="780" height="648" alt="SCR-20260701-nrtm" src="https://github.com/user-attachments/assets/2cffffb9-24b7-4b71-9886-b34c82735b9a" />

## Summary

- Add an appearance option for text-based input source icons.
- Render supported input sources as clean text glyphs when the option is enabled.
- Keep the original icon style available when the option is disabled.
- Add localized strings for the new option.